### PR TITLE
fix on missing title

### DIFF
--- a/homr/title_detection.py
+++ b/homr/title_detection.py
@@ -47,9 +47,8 @@ def _detect_title_task(debug: Debug, top_staff: Staff) -> str:
 
     ocr_input: str = debug.write_model_input_image("_tesseract_input.png", above_staff)
     ocr_results = _reader(ocr_input)
-    if not ocr_results:
+    if not ocr_results or not ocr_results[0]:
         return ""
-    ocr_results = _reader(ocr_input)
 
     # Each result is (bbox, text, confidence)
     # Pick the text with the largest bbox area


### PR DESCRIPTION
The fix implemented addresses issue where the OCR function could return None or an empty result, causing the max() function to fail when trying to iterate over ocr_results[0]. The improved null checks ensure the code handles these edge cases gracefully by returning an empty string when no valid OCR results are available.
