### PR TITLE
Make onnx converting cli based

### DIFF
--- a/homr/transformer/staff2score.py
+++ b/homr/transformer/staff2score.py
@@ -41,9 +41,8 @@ class Staff2Score:
         nonote_token = np.full((len(x), 1), self.config.nonote_token, dtype=np.int64)
 
         # Generate context with encoder
-        t0 = perf_counter()
         context = self.encoder.generate(x)
-        print(f"Encoder time: {perf_counter() - t0}")
+
         # Make a prediction using decoder
         out = self.decoder.generate(
             start_token,

--- a/homr/transformer/staff2score.py
+++ b/homr/transformer/staff2score.py
@@ -41,8 +41,9 @@ class Staff2Score:
         nonote_token = np.full((len(x), 1), self.config.nonote_token, dtype=np.int64)
 
         # Generate context with encoder
+        t0 = perf_counter()
         context = self.encoder.generate(x)
-
+        print(f"Encoder time: {perf_counter() - t0}")
         # Make a prediction using decoder
         out = self.decoder.generate(
             start_token,

--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -1,7 +1,7 @@
 # ruff: noqa: T201
 
-import os
 import argparse
+import os
 
 from homr.simple_logging import eprint
 from training.onnx.convert import (
@@ -42,27 +42,17 @@ def convert(transformer_path: str | None = None, segnet_path: str | None = None)
         os.remove("decoder_weights.pt")
         os.remove("encoder_weights.pt")
 
+
 def main():
     parser = argparse.ArgumentParser(
-        prog="Onnx converter",
-        description="Convert pytorch models to onnx format"
+        prog="Onnx converter", description="Convert pytorch models to onnx format"
     )
-    parser.add_argument(
-        "--path_transformer",
-        type=str,
-        help="Path to the transformer weights"
-    )
-    parser.add_argument(
-        "--path_segnet",
-        type=str,
-        help="Path to the segnet weights"
-    )
+    parser.add_argument("--path_transformer", type=str, help="Path to the transformer weights")
+    parser.add_argument("--path_segnet", type=str, help="Path to the segnet weights")
     args = parser.parse_args()
 
-    convert(
-        transformer_path=args.path_transformer,
-        segnet_path=args.path_segnet
-    )
+    convert(transformer_path=args.path_transformer, segnet_path=args.path_segnet)
+
 
 if __name__ == "__main__":
     main()

--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -1,7 +1,9 @@
 # ruff: noqa: T201
 
 import os
+import argparse
 
+from homr.simple_logging import eprint
 from training.onnx.convert import (
     convert_decoder,
     convert_encoder,
@@ -12,42 +14,56 @@ from training.onnx.simplify import main as simplify_onnx_model
 from training.onnx.split_weights import split_weights
 
 
-def convert_all(transformer_path: str | None = None, segnet_path: str | None = None) -> None:
+def convert(transformer_path: str | None = None, segnet_path: str | None = None) -> None:
     if transformer_path is None and segnet_path is None:
-        raise FileExistsError("You did not specify the path of your pytorch models")
+        raise FileExistsError("You did not specify a path to the weights")
 
     # Warnings might occur
     if segnet_path is not None:
-        path_to_segnet = convert_segnet()
-        simplify_onnx_model(path_to_segnet)
-        print(path_to_segnet)
+        path_onnx_segnet = convert_segnet(segnet_path)
+        simplify_onnx_model(path_onnx_segnet)
+        eprint(path_onnx_segnet)
 
     if transformer_path is not None:
         split_weights(transformer_path)  # Make sure to the filepath of the transformer!
-        path_to_encoder = convert_encoder()
-        simplify_onnx_model(path_to_encoder)
-        print(path_to_encoder)
+        path_onnx_encoder = convert_encoder(transformer_path)
+        simplify_onnx_model(path_onnx_encoder)
+        eprint(path_onnx_encoder)
 
-        path_to_decoder = convert_decoder()
-        simplify_onnx_model(path_to_decoder)
+        path_onnx_decoder = convert_decoder(transformer_path)
+        simplify_onnx_model(path_onnx_decoder)
 
         # Only the decoder gets quantized.
-        # The segnet showed 80% worse performance on x86-64.
-        # Only improved size by around 15MB without any speedups
-        # (maybe even slowing inference down).
-        # FP16 slowed inference speed down (CPU).
-        quantization_int8(path_to_decoder)
-        print(path_to_decoder)
+        # The encoder and segnet need quint8 which has worse inference times on x86 cpus.
+        # Although fp16 slowed inference down on cpu, it could be worth it to use fp16.
+        quantization_int8(path_onnx_decoder)
+        eprint(path_onnx_decoder)
 
-    os.remove("decoder_weights.pt")
-    os.remove("encoder_weights.pt")
+        os.remove("decoder_weights.pt")
+        os.remove("encoder_weights.pt")
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="Onnx converter",
+        description="Convert pytorch models to onnx format"
+    )
+    parser.add_argument(
+        "--path_transformer",
+        type=str,
+        help="Path to the transformer weights"
+    )
+    parser.add_argument(
+        "--path_segnet",
+        type=str,
+        help="Path to the segnet weights"
+    )
+    args = parser.parse_args()
+
+    convert(
+        transformer_path=args.path_transformer,
+        segnet_path=args.path_segnet
+    )
 
 
 if __name__ == "__main__":
-    # Converts pytorch models used by homr to onnx
-
-    from homr.segmentation.config import segnet_path_torch
-    from homr.transformer.configs import Config
-    from training.onnx.main import convert_all
-
-    convert_all(transformer_path=Config().filepaths.checkpoint, segnet_path=segnet_path_torch)
+    main()

--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -64,6 +64,5 @@ def main():
         segnet_path=args.path_segnet
     )
 
-
 if __name__ == "__main__":
     main()

--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -43,7 +43,7 @@ def convert(transformer_path: str | None = None, segnet_path: str | None = None)
         os.remove("encoder_weights.pt")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="Onnx converter", description="Convert pytorch models to onnx format"
     )

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -1,11 +1,12 @@
 import os
+import argparse
 
 from onnxruntime.quantization import QuantType, quantize_dynamic
 from onnxruntime.quantization.shape_inference import quant_pre_process
 
 
 def quantization_int8(
-    model_path: str, out_path: str | None = None, preprocess: bool = True
+    model_path: str, out_path: str = None, arm_optimized: bool = False
 ) -> None:
     """
     Dynamic Quantization of an onnx model to int8
@@ -17,15 +18,50 @@ def quantization_int8(
     """
     if out_path is None:
         out_path = model_path
-
-    if preprocess:
-        quant_pre_process(
+    
+    quant_pre_process(
             model_path, "model_preprocessed.onnx"
         )  # Preprocess model for better quantization results
+
+    if arm_optimized:
+        # Quint8 is slower on x86; faster on arm (sometimes)
+        print('arm')
+        quantize_dynamic("model_preprocessed.onnx", out_path, weight_type=QuantType.QUInt8)
+    else:
         quantize_dynamic(
             "model_preprocessed.onnx", out_path, weight_type=QuantType.QInt8
-        )  # Quint8 is slower on x86-64
-    else:
-        quantize_dynamic(model_path, out_path, weight_type=QuantType.QUInt8)
-
+        )
     os.remove("model_preprocessed.onnx")
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="quantization_int8",
+        description="Quantize an onnx model to dynamic int8"
+    )
+    parser.add_argument(
+        "model_path",
+        type=str,
+        help="Path to the .onnx model"
+    )
+    parser.add_argument(
+        "--out_path",
+        type=str,
+        default=None,
+        help="Path to save the quantized .onnx model"
+    )
+    parser.add_argument(
+        "--arm_optimized",
+        action="store_true",
+        default=True,
+        help="Optimize model for arm"
+    )    
+    args = parser.parse_args()
+
+    quantization_int8(
+        args.model_path, 
+        args.out_path,
+        args.arm_optimized
+    )
+
+if __name__ == '__main__':
+    main()

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -5,7 +5,9 @@ from onnxruntime.quantization import QuantType, quantize_dynamic
 from onnxruntime.quantization.shape_inference import quant_pre_process
 
 
-def quantization_int8(model_path: str, out_path: str | None = None, arm_optimized: bool = False) -> None:
+def quantization_int8(
+    model_path: str, out_path: str | None = None, arm_optimized: bool = False
+) -> None:
     """
     Dynamic Quantization of an onnx model to int8
     Args:

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -5,7 +5,7 @@ from onnxruntime.quantization import QuantType, quantize_dynamic
 from onnxruntime.quantization.shape_inference import quant_pre_process
 
 
-def quantization_int8(model_path: str, out_path: str = None, arm_optimized: bool = False) -> None:
+def quantization_int8(model_path: str, out_path: str | None = None, arm_optimized: bool = False) -> None:
     """
     Dynamic Quantization of an onnx model to int8
     Args:
@@ -29,7 +29,7 @@ def quantization_int8(model_path: str, out_path: str = None, arm_optimized: bool
     os.remove("model_preprocessed.onnx")
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         prog="quantization_int8", description="Quantize an onnx model to dynamic int8"
     )

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -18,14 +18,13 @@ def quantization_int8(
     """
     if out_path is None:
         out_path = model_path
-    
+
     quant_pre_process(
             model_path, "model_preprocessed.onnx"
         )  # Preprocess model for better quantization results
 
     if arm_optimized:
         # Quint8 is slower on x86; faster on arm (sometimes)
-        print('arm')
         quantize_dynamic("model_preprocessed.onnx", out_path, weight_type=QuantType.QUInt8)
     else:
         quantize_dynamic(
@@ -54,11 +53,11 @@ def main():
         action="store_true",
         default=True,
         help="Optimize model for arm"
-    )    
+    )
     args = parser.parse_args()
 
     quantization_int8(
-        args.model_path, 
+        args.model_path,
         args.out_path,
         args.arm_optimized
     )

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -1,13 +1,11 @@
-import os
 import argparse
+import os
 
 from onnxruntime.quantization import QuantType, quantize_dynamic
 from onnxruntime.quantization.shape_inference import quant_pre_process
 
 
-def quantization_int8(
-    model_path: str, out_path: str = None, arm_optimized: bool = False
-) -> None:
+def quantization_int8(model_path: str, out_path: str = None, arm_optimized: bool = False) -> None:
     """
     Dynamic Quantization of an onnx model to int8
     Args:
@@ -20,47 +18,32 @@ def quantization_int8(
         out_path = model_path
 
     quant_pre_process(
-            model_path, "model_preprocessed.onnx"
-        )  # Preprocess model for better quantization results
+        model_path, "model_preprocessed.onnx"
+    )  # Preprocess model for better quantization results
 
     if arm_optimized:
         # Quint8 is slower on x86; faster on arm (sometimes)
         quantize_dynamic("model_preprocessed.onnx", out_path, weight_type=QuantType.QUInt8)
     else:
-        quantize_dynamic(
-            "model_preprocessed.onnx", out_path, weight_type=QuantType.QInt8
-        )
+        quantize_dynamic("model_preprocessed.onnx", out_path, weight_type=QuantType.QInt8)
     os.remove("model_preprocessed.onnx")
+
 
 def main():
     parser = argparse.ArgumentParser(
-        prog="quantization_int8",
-        description="Quantize an onnx model to dynamic int8"
+        prog="quantization_int8", description="Quantize an onnx model to dynamic int8"
+    )
+    parser.add_argument("model_path", type=str, help="Path to the .onnx model")
+    parser.add_argument(
+        "--out_path", type=str, default=None, help="Path to save the quantized .onnx model"
     )
     parser.add_argument(
-        "model_path",
-        type=str,
-        help="Path to the .onnx model"
-    )
-    parser.add_argument(
-        "--out_path",
-        type=str,
-        default=None,
-        help="Path to save the quantized .onnx model"
-    )
-    parser.add_argument(
-        "--arm_optimized",
-        action="store_true",
-        default=True,
-        help="Optimize model for arm"
+        "--arm_optimized", action="store_true", default=True, help="Optimize model for arm"
     )
     args = parser.parse_args()
 
-    quantization_int8(
-        args.model_path,
-        args.out_path,
-        args.arm_optimized
-    )
+    quantization_int8(args.model_path, args.out_path, args.arm_optimized)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hey!
I thought it would be good to make the converting process from .pth to .onnx CLI based.
With this PR a .pth can easily be converted to .onnx like this (tested on windows):
`python -m training.onnx.main --path_segnet "segnet.pth" --path_transformer "transformer.pth"`.
Also quantization is CLI based. This makes it easier to experiment with different quantization types. 
