### PR TITLE
KV Cache for the Decoder

### DIFF
--- a/homr/transformer/decoder_inference.py
+++ b/homr/transformer/decoder_inference.py
@@ -65,7 +65,9 @@ class ScoreDecoder:
             x_articulations = out_articulations[:, -1:]
             
             if step != 0: # after the first step we don't pass the full context into the decoder
-                context = kwargs["context"][:, :1] 
+                # x_transformers uses [:, :0] to split the context
+                # which caused a Reshape error when loading the onnx model
+                context = kwargs["context"][:, :1]
 
             inputs = {
                 "rhythms": x_rhythm,
@@ -78,6 +80,7 @@ class ScoreDecoder:
             }
             for i in range(32):
                 inputs[kv_input_names[i]] = cache[i]
+
 
             rhythmsp, pitchsp, liftsp, positionsp, articulationsp, *cache = self.net.run(
                 output_names=[

--- a/homr/transformer/decoder_inference.py
+++ b/homr/transformer/decoder_inference.py
@@ -53,32 +53,40 @@ class ScoreDecoder:
         clef_upper = "clef_G2"
         clef_lower = "clef_F4"
         states = np.array([[self.state_vocab[f"{key}+{clef_upper}+{clef_lower}"]]])
+        cache, kv_input_names, kv_output_names = self.init_cache()
+        context = kwargs["context"]
 
         symbols: list[EncodedSymbol] = []
 
-        for _ in range(self.max_seq_len):
-            x_lift = out_lift[:, -self.max_seq_len :]
-            x_pitch = out_pitch[:, -self.max_seq_len :]
-            x_rhythm = out_rhythm[:, -self.max_seq_len :]
-            x_articulations = out_articulations[:, -self.max_seq_len :]
-            context = kwargs["context"]
+        for step in range(self.max_seq_len):
+            x_lift = out_lift[:, -1:] # for all: shape=(1,1)
+            x_pitch = out_pitch[:, -1:]
+            x_rhythm = out_rhythm[:, -1:]
+            x_articulations = out_articulations[:, -1:]
+            
+            if step != 0: # after the first step we don't pass the full context into the decoder
+                context = kwargs["context"][:, :1] 
 
             inputs = {
                 "rhythms": x_rhythm,
                 "pitchs": x_pitch,
                 "lifts": x_lift,
                 "articulations": x_articulations,
-                "states": states,
+                "states": states[:, -1:],
                 "context": context,
+                "cache_len": np.array([step])
             }
+            for i in range(32):
+                inputs[kv_input_names[i]] = cache[i]
 
-            rhythmsp, pitchsp, liftsp, positionsp, articulationsp = self.net.run(
+            rhythmsp, pitchsp, liftsp, positionsp, articulationsp, *cache = self.net.run(
                 output_names=[
                     "out_rhythms",
                     "out_pitchs",
                     "out_lifts",
                     "out_positions",
                     "out_articulations",
+                    *kv_output_names
                 ],
                 input_feed=inputs,
             )
@@ -136,6 +144,17 @@ class ScoreDecoder:
             out_articulations = np.concatenate((out_articulations, articulation_sample), axis=-1)
 
         return symbols
+
+
+    def init_cache(self, cache_len=0):
+        cache = []
+        input_names = []    
+        output_names = []
+        for i in range(32):
+            cache.append(np.zeros((1, 8, cache_len, 64), dtype=np.float32))
+            input_names.append(f"cache_in{i}")
+            output_names.append(f"cache_out{i}")
+        return cache, input_names, output_names
 
 
 def top_k(logits: NDArray, thres: float = 0.9) -> NDArray:

--- a/homr/transformer/decoder_inference.py
+++ b/homr/transformer/decoder_inference.py
@@ -149,7 +149,7 @@ class ScoreDecoder:
 
         return symbols
 
-    def init_cache(self, cache_len=0):
+    def init_cache(self, cache_len: int = 0) -> tuple[list[NDArray], list[str], list[str]]:
         cache = []
         input_names = []
         output_names = []

--- a/homr/transformer/decoder_inference.py
+++ b/homr/transformer/decoder_inference.py
@@ -60,13 +60,13 @@ class ScoreDecoder:
         symbols: list[EncodedSymbol] = []
 
         for step in range(self.max_seq_len):
-            x_lift = out_lift[:, -1:] # for all: shape=(1,1)
+            x_lift = out_lift[:, -1:]  # for all: shape=(1,1)
             x_pitch = out_pitch[:, -1:]
             x_rhythm = out_rhythm[:, -1:]
             x_articulations = out_articulations[:, -1:]
             x_states = states[:, -1:]
 
-            if step != 0: # after the first step we don't pass the full context into the decoder
+            if step != 0:  # after the first step we don't pass the full context into the decoder
                 # x_transformers uses [:, :0] to split the context
                 # which caused a Reshape error when loading the onnx model
                 context = context_reduced
@@ -78,7 +78,7 @@ class ScoreDecoder:
                 "articulations": x_articulations,
                 "states": x_states,
                 "context": context,
-                "cache_len": np.array([step])
+                "cache_len": np.array([step]),
             }
             for i in range(32):
                 inputs[kv_input_names[i]] = cache[i]
@@ -90,7 +90,7 @@ class ScoreDecoder:
                     "out_lifts",
                     "out_positions",
                     "out_articulations",
-                    *kv_output_names
+                    *kv_output_names,
                 ],
                 input_feed=inputs,
             )
@@ -149,10 +149,9 @@ class ScoreDecoder:
 
         return symbols
 
-
     def init_cache(self, cache_len=0):
         cache = []
-        input_names = []    
+        input_names = []
         output_names = []
         for i in range(32):
             cache.append(np.zeros((1, 8, cache_len, 64), dtype=np.float32))

--- a/homr/transformer/staff2score.py
+++ b/homr/transformer/staff2score.py
@@ -37,8 +37,8 @@ class Staff2Score:
         t0 = perf_counter()
 
         # Create special tokens
-        start_token = np.full((len(x), 1), self.config.bos_token, dtype=np.int64)
-        nonote_token = np.full((len(x), 1), self.config.nonote_token, dtype=np.int64)
+        start_token = np.array([[1]], dtype=np.int64)
+        nonote_token = np.array([[0]], dtype=np.int64)
 
         # Generate context with encoder
         context = self.encoder.generate(x)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,10 @@ implicit_reexport = false
 strict_equality = true
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "training.architecture.transformer.custom_x_transformer"
+ignore_errors = true
+
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = 10

--- a/training/architecture/transformer/custom_x_transformer.py
+++ b/training/architecture/transformer/custom_x_transformer.py
@@ -1,0 +1,362 @@
+"""
+Version of x_transforer.x_transformer to support kv caching for homr's decoder in onnx.
+"""
+
+from x_transformers.x_transformers import *
+
+class CustomAttentionLayers(AttentionLayers):
+    def forward(
+        self,
+        x,
+        context = None,
+        mask = None,
+        context_mask = None,
+        attn_mask = None,
+        self_attn_kv_mask = None,
+        mems = None,
+        mem_masks = None,
+        seq_start_pos: Tensor | None = None,
+        seq_pos_offset: int = 0,
+        cache: LayerIntermediates | None = None,
+        input_not_include_cache = False,
+        cache_age = 1,
+        return_hiddens = False,
+        rotary_pos_emb = None,
+        pos = None,
+        context_pos = None,
+        attn_bias = None,
+        deep_embeds_and_ids: tuple[nn.Parameter, Tensor] | None = None,
+        self_attn_additional_kv: (
+            LayerIntermediates |
+            list[tuple[Tensor, Tensor]]
+            | None
+        ) = None,
+        additional_kv_mask = None,
+        detach_additional_kv = False,
+        route_additional_kv_to_top = True,
+        condition = None,
+        in_attn_cond = None, # https://arxiv.org/abs/2105.04090
+        layers_execute_order: tuple[int, ...] | None = None
+    ):
+        assert not (self.cross_attend ^ exists(context)), 'context must be passed in if cross_attend is set to True'
+        assert not (exists(condition) ^ self.need_condition), 'condition needs to be passed in if using adaptive layernorm or vice versa'
+
+        # handle condition
+
+        if exists(condition):
+            assert condition.shape[-1] == self.dim_condition, f'expected condition dimension of {self.dim_condition} but received {condition.shape[-1]}'
+
+            assert condition.ndim in {2, 3}
+
+            if condition.ndim == 2:
+                condition = rearrange(condition, 'b d -> b 1 d')
+
+            condition = self.adaptive_mlp(condition)
+
+        # setup maybe layernorm kwarg
+
+        norm_kwargs = dict()
+
+        if self.norm_need_condition:
+            norm_kwargs.update(condition = condition)
+
+        # maybe post branch fn conditioning (DiT paper's ada-ln-zero)
+
+        block_forward_kwargs = dict()
+
+        if self.post_branch_fn_needs_condition:
+            block_forward_kwargs.update(condition = condition)
+
+        # initialize accums
+
+        hiddens = []
+        layer_hiddens = []
+        intermediates = []
+
+        prev_attn = None
+        prev_cross_attn = None
+
+        mems = mems.copy() if exists(mems) else [None] * self.num_attn_layers
+        mem_masks = mem_masks.copy() if exists(mem_masks) else [None] * self.num_attn_layers
+
+        # handle left padded sequences
+
+        if exists(seq_start_pos):
+            seq_arange = arange(x.shape[-2], device = x.device, dtype = torch.long)
+            left_pad_mask = seq_arange >= seq_start_pos[..., None]
+
+            if exists(self_attn_kv_mask):
+                self_attn_kv_mask = self_attn_kv_mask & left_pad_mask
+            else:
+                self_attn_kv_mask = left_pad_mask
+
+        # rotary positions
+
+        cross_attn_rotary_pos_emb = dict()
+
+        if exists(self.rotary_pos_emb):
+            if not exists(rotary_pos_emb):
+                maybe_mem = first(mems, None) # todo - handle edge case where different layers get different memory lengths. don't think this will ever come up but who knows
+                mem_len = maybe_mem.shape[1] if exists(maybe_mem) else 0
+
+                if not exists(pos):
+                    pos = arange(x.shape[1] + mem_len + seq_pos_offset, device = x.device) - mem_len
+
+                rotary_pos_emb = self.rotary_pos_emb(pos)
+
+            # allow for rotary positions for context if provided
+
+            if exists(context_pos):
+                assert self.cross_attend
+                context_rotary_pos_emb = self.rotary_pos_emb(context_pos)
+
+                cross_attn_rotary_pos_emb.update(
+                    rotary_pos_emb = rotary_pos_emb,
+                    context_rotary_pos_emb = context_rotary_pos_emb
+                )
+
+        # assume cached key / values
+
+        prev_cache_length = 0
+
+        attn_cache = []
+
+        if exists(cache):
+            assert self.causal and not exists(attn_mask)
+
+            prev_cache_length = cache.cache_length
+
+            if exists(context) and False: # this is done in the inference code
+                context = context[:, :0]
+
+            if cache_age > 0 and False: # has no impact
+                x = x[:, -cache_age:] # for spec decoding, may be greater than 1
+
+                if exists(deep_embeds_and_ids):
+                    deep_embeds, token_ids = deep_embeds_and_ids
+                    token_ids = token_ids[:, -cache_age:]
+                    deep_embeds_and_ids = (deep_embeds, token_ids)
+
+            attn_cache = cache.attn_intermediates
+
+        next_cache_length = x.shape[1]
+
+        iter_attn_cache = iter(attn_cache)
+
+        # handle deep embeds if needed
+
+        deep_embeds = []
+
+        if exists(deep_embeds_and_ids):
+            deep_embeds, token_ids = deep_embeds_and_ids
+            deep_embeds_across_depth = deep_embeds[token_ids]
+            deep_embeds = rearrange(deep_embeds_across_depth, 'b n l d -> l b n d')
+
+        deep_embeds_iter = iter(deep_embeds)
+
+        # setup multistreams if needed
+
+        streams = self.num_residual_streams
+        is_multistream = streams > 1
+
+        if is_multistream:
+            x = einx.add('b n d, s d -> (b s) n d', x, self.stream_emb)
+
+        # get layers to be executed
+
+        layer_variables = (
+            self.layer_types,
+            self.skip_combines,
+            self.layers,
+            self.layer_dropouts,
+            self.layer_integrators
+        )
+
+        # able to override the layers execution order on forward, for trying to depth extrapolate
+
+        layers_execute_order = default(layers_execute_order, self.layers_execute_order)
+        layer_variables = tuple(tuple(layer_variable[i] for i in layers_execute_order) for layer_variable in layer_variables)
+
+        # additional self attn key / values - say coming from vlm
+
+        if exists(self_attn_additional_kv) and route_additional_kv_to_top:
+
+            if isinstance(self_attn_additional_kv, LayerIntermediates):
+                self_attn_additional_kv = get_cached_kvs(self_attn_additional_kv)
+
+            if detach_additional_kv:
+                self_attn_additional_kv = detach_all(self_attn_additional_kv)
+
+            num_self_attns = sum([layer_type == 'a' for layer_type in first(layer_variables)])
+
+            self_attn_additional_kv = self_attn_additional_kv[-num_self_attns:]
+            self_attn_additional_kv = [None] * (num_self_attns - len(self_attn_additional_kv)) + self_attn_additional_kv
+
+        iter_self_attn_kv = iter(default(self_attn_additional_kv, ()))
+
+        # derived input for reinjection if needed
+
+        inp_inject = None
+
+        if self.reinject_input:
+            assert not exists(in_attn_cond)
+            inp_inject = self.reinject_input_proj(x)
+
+        elif exists(in_attn_cond):
+            # handle in-attention conditioning, which serves the same purpose of having the network learn the residual
+            inp_inject = in_attn_cond if in_attn_cond.ndim == 3 else rearrange(in_attn_cond, 'b d -> b 1 d')
+
+        if exists(inp_inject) and exists(self.learned_reinject_input_gate):
+            inp_inject_gate = self.learned_reinject_input_gate(x).sigmoid()
+            inp_inject = inp_inject * inp_inject_gate
+
+        # store all hiddens for skips
+
+        skip_hiddens = []
+
+        # for value residuals
+
+        first_self_attn_inter = None
+        first_cross_attn_inter = None
+
+        # go through the attention and feedforward layers
+
+        for ind, (layer_type, skip_combine, (norm, block, residual_fn), layer_dropout, layer_integrator) in enumerate(zip(*layer_variables)):
+            is_last = ind == (len(self.layers) - 1)
+
+            # handle skip connections
+
+            skip_hiddens.append(x)
+
+            if exists(skip_combine):
+                x = skip_combine(x, skip_hiddens)
+
+            # layer dropout
+
+            if self.training and layer_dropout > 0. and random() < layer_dropout:
+                continue
+
+            if layer_type == 'a':
+                if return_hiddens:
+                    hiddens.append(x)
+
+                layer_mem = mems.pop(0) if mems else None
+                layer_mem_mask = mem_masks.pop(0) if mem_masks else None
+
+            if layer_type == 'c':
+                if self.training and self.cross_attn_tokens_dropout > 0.:
+                    context, context_mask = dropout_seq(context, context_mask, self.cross_attn_tokens_dropout)
+
+            x, inner_residual, residual_kwargs = residual_fn.prepare(x)
+
+            layer_hiddens.append(x)
+
+            if exists(layer_integrator):
+                x = layer_integrator(x, layer_hiddens)
+
+            pre_norm, post_branch_norm, post_main_norm = norm
+
+            if self.need_condition:
+                pre_norm = maybe(partial)(pre_norm, **norm_kwargs)
+                post_branch_norm = maybe(partial)(post_branch_norm, **norm_kwargs)
+                post_main_norm = maybe(partial)(post_main_norm, **norm_kwargs)
+
+            if exists(inp_inject):
+                x = x + inp_inject
+
+            if exists(pre_norm):
+                x = pre_norm(x)
+
+                if layer_type == 'a' and exists(layer_mem):
+                    layer_mem = pre_norm(layer_mem)
+
+            block = partial(block, **block_forward_kwargs)
+
+            # handle maybe value residuals
+
+            maybe_self_attn_value_residual = None
+            maybe_cross_attn_value_residual = None
+
+            if self.add_value_residual:
+                if exists(first_self_attn_inter):
+                    maybe_self_attn_value_residual = first_self_attn_inter.values
+
+                if exists(first_cross_attn_inter):
+                    maybe_cross_attn_value_residual = first_cross_attn_inter.values
+
+            # forward depending on layer type
+
+            layer_cache = None
+            if layer_type in ('a', 'c'):
+                layer_cache = next(iter_attn_cache, None)
+
+
+            if layer_type == 'a':
+                out, inter = block(x, mask = mask, context_mask = self_attn_kv_mask, attn_mask = attn_mask, rel_pos = self.rel_pos, pos = pos, rotary_pos_emb = rotary_pos_emb, additional_key_values = layer_cache, additional_key_value_mask = additional_kv_mask, prev_attn = prev_attn, cache = next(iter_attn_cache, None), mem = layer_mem, mem_mask = layer_mem_mask, attn_bias = attn_bias, value_residual = maybe_self_attn_value_residual, return_intermediates = True)
+            elif layer_type == 'c':
+                out, inter = block(x, context = context, mask = mask, context_mask = context_mask, prev_attn = prev_cross_attn, cache = layer_cache, value_residual = maybe_cross_attn_value_residual, **cross_attn_rotary_pos_emb, return_intermediates = True)
+            elif layer_type == 'f':
+                out = block(x, deep_embed = next(deep_embeds_iter, None))
+
+            # store first self or cross attention intermediate for value residual
+
+            if not exists(first_self_attn_inter) and layer_type == 'a':
+                first_self_attn_inter = inter
+
+            if not exists(first_cross_attn_inter) and layer_type == 'c':
+                first_cross_attn_inter = inter
+
+            if exists(post_branch_norm):
+                out = post_branch_norm(out)
+
+            x = residual_fn(out, inner_residual, **residual_kwargs)
+
+            if layer_type in ('a', 'c') and return_hiddens:
+                inter.layer_type = layer_type
+                intermediates.append(inter)
+
+            if layer_type == 'a' and self.residual_attn:
+                prev_attn = inter.pre_softmax_attn
+            elif layer_type == 'c' and self.cross_residual_attn:
+                prev_cross_attn = inter.pre_softmax_attn
+
+            if exists(post_main_norm):
+                x = post_main_norm(x)
+
+        if return_hiddens:
+            layer_hiddens.append(x)
+
+        if self.softclamp_output:
+            x = softclamp(x, self.softclamp_output_value)
+
+        final_norm = self.final_norm
+
+        if self.need_condition:
+            final_norm = maybe(partial)(final_norm, **norm_kwargs)
+
+        # take care of multistreams if needed, use sum for now
+
+        if is_multistream:
+            x = reduce(x, '(b s) n d -> b n d', 'sum', s = streams)
+
+        x = final_norm(x)
+
+        if not return_hiddens:
+            return x
+
+        intermediates = LayerIntermediates(
+            hiddens = hiddens,
+            last_hidden = x,
+            attn_intermediates = intermediates,
+            layer_hiddens = layer_hiddens,
+            cache_length = next_cache_length + prev_cache_length
+        )
+
+        return x, intermediates
+
+
+
+class CustomDecoder(AttentionLayers):
+    def __init__(self, **kwargs):
+        assert 'causal' not in kwargs, 'cannot set causality on decoder'
+        super().__init__(causal = True, **kwargs)

--- a/training/architecture/transformer/custom_x_transformer.py
+++ b/training/architecture/transformer/custom_x_transformer.py
@@ -1,5 +1,7 @@
 """
-Version of x_transforer.x_transformer to support kv caching for homr's decoder in onnx.
+Version of x_transformers.x_transformer to support kv caching for homr's decoder in onnx.
+Used x_transformers==2.4.9 
+I had issues with 2.9.2
 """
 
 from x_transformers.x_transformers import *

--- a/training/architecture/transformer/decoder.py
+++ b/training/architecture/transformer/decoder.py
@@ -81,8 +81,8 @@ class ScoreTransformerWrapper(nn.Module):
         lifts: torch.Tensor,
         articulations: torch.Tensor,
         states: torch.Tensor,
-        cache_len: torch.Tensor,
         context: torch.Tensor,
+        cache_len: torch.Tensor,
         mask: torch.Tensor | None = None,
         *cache: torch.Tensor
     ) -> Any:
@@ -181,10 +181,10 @@ class ScoreDecoder(nn.Module):
         b, t = start_tokens.shape
 
         self.net.eval()
-        out_rhythm = torch.tensor([[1]], dtype=torch.long, device=self.device)
-        out_pitch = torch.tensor([[0]], dtype=torch.long, device=self.device)
-        out_lift = torch.tensor([[0]], dtype=torch.long, device=self.device)
-        out_articulations = torch.tensor([[0]], dtype=torch.long, device=self.device)
+        out_rhythm = start_tokens
+        out_pitch = nonote_tokens
+        out_lift = nonote_tokens
+        out_articulations = nonote_tokens
         mask = kwargs.pop("mask", None)
         context_first = kwargs["context"]
         context_later = context_first[:, :0]
@@ -221,8 +221,8 @@ class ScoreDecoder(nn.Module):
                 x_lift,
                 x_articulations,
                 states[:, -1:],
-                torch.Tensor([step], device=self.device).long(),
                 context,
+                torch.Tensor([step], device=self.device).long(),
                 mask,
                 *cache
             )

--- a/training/architecture/transformer/decoder.py
+++ b/training/architecture/transformer/decoder.py
@@ -84,8 +84,10 @@ class ScoreTransformerWrapper(nn.Module):
         context: torch.Tensor,
         cache_len: torch.Tensor,
         mask: torch.Tensor | None = None,
-        *cache: torch.Tensor
+        **kwargs: torch.Tensor
     ) -> Any:
+        cache = kwargs.pop("cache")
+
         x = (
             self.rhythm_emb(rhythms)
             + self.pitch_emb(pitchs)
@@ -188,7 +190,7 @@ class ScoreDecoder(nn.Module):
         out_lift = nonote_tokens
         out_articulations = nonote_tokens
         mask = kwargs.pop("mask", None)
-        context_first = kwargs["context"]
+        context_first = kwargs.pop("context")
         context_later = context_first[:, :0]
 
         if mask is None:
@@ -226,7 +228,8 @@ class ScoreDecoder(nn.Module):
                 context,
                 torch.Tensor([step], device=self.device).long(),
                 mask,
-                *cache
+                cache=cache,
+                **kwargs
             )
 
             filtered_lift_logits = top_k(liftsp[:, -1, :], thres=filter_thres)

--- a/training/architecture/transformer/decoder.py
+++ b/training/architecture/transformer/decoder.py
@@ -1,5 +1,5 @@
 from math import ceil
-from typing import Any, List
+from typing import Any
 
 import torch
 import torch.nn.functional as F
@@ -111,8 +111,9 @@ class ScoreTransformerWrapper(nn.Module):
         )
 
         # get the kv cache tensors from the LayerIntermediates class
-        # the cache is built up like this: LayerIntermediates(atten_intermediates=Intermediates(cached_kv=(cache_k, cache_v)))
-        # the cache is alternating between the shapes (batch_size, 8, seq_len, 64) and (batch_size, 8, 1281, 64)
+        # the cache is built up like this:
+        # LayerIntermediates(atten_intermediates=Intermediates(cached_kv=(cache_k, cache_v)))
+        # cache is alternating between the shapes (batch, 8, seq_len, 64) and (batch, 8, 1281, 64)
         # 8 probably corresponds to the number of decoder_heads
         # 1281 is the same as the encoder output
         cache_out = []
@@ -419,7 +420,9 @@ class ScoreDecoder(nn.Module):
         return loss
 
 
-def init_cache(cache_len=0):
+def init_cache(
+    cache_len: int = 0,
+) -> tuple[list[torch.Tensor], list[str], list[str], dict[str, dict[int, str]], int]:
     cache = []
     input_names = []
     output_names = []

--- a/training/architecture/transformer/tromr_arch.py
+++ b/training/architecture/transformer/tromr_arch.py
@@ -57,8 +57,8 @@ class TrOMR(nn.Module):
 
     @torch.no_grad()
     def generate(self, x: torch.Tensor) -> list[EncodedSymbol]:
-        start_token = (torch.LongTensor([self.config.bos_token] * len(x))[:, None]).to(x.device)
-        nonote_token = (torch.LongTensor([self.config.nonote_token] * len(x))[:, None]).to(x.device)
+        start_token = torch.tensor([[1]], dtype=torch.long, device=x.device)
+        nonote_token = torch.tensor([[0]], dtype=torch.long, device=x.device)
 
         context = self.encoder(x)
         out = self.decoder.generate(start_token, nonote_token, context=context)

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -39,7 +39,7 @@ class DecoderWrapper(torch.nn.Module):
             context,
             cache_len,
             None,
-            *cache
+            cache=cache
         )
         return out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, *cache
 

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -9,6 +9,7 @@ from training.architecture.segmentation.model import create_segnet  # type: igno
 from training.architecture.transformer.decoder import (
     ScoreTransformerWrapper,
     get_score_wrapper,
+    init_cache
 )
 from training.architecture.transformer.encoder import get_encoder
 
@@ -145,18 +146,6 @@ def convert_decoder() -> str:
         export_params=True,
     )
     return path_out
-
-def init_cache(cache_len=0):
-    cache = []
-    input_names = []    
-    output_names = []
-    dynamic = {}
-    for i in range(32):
-        cache.append(torch.zeros((1, 8, cache_len, 64), dtype=torch.float32))
-        input_names.append(f"cache_in{i}")
-        output_names.append(f"cache_out{i}")
-        dynamic[f"cache_in{i}"] = {2: "seq_len"}
-    return cache, input_names, output_names, dynamic, cache_len
 
 def convert_segnet() -> str:
     """

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -26,17 +26,21 @@ class DecoderWrapper(torch.nn.Module):
         articulations: torch.Tensor,
         states: torch.Tensor,
         context: torch.Tensor,
+        cache_len: torch.Tensor,
+        *cache: torch.Tensor
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, _x = self.model(
-            rhythms=rhythms,
-            pitchs=pitchs,
-            lifts=lifts,
-            articulations=articulations,
-            states=states,
-            mask=None,
-            context=context,
+        out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, _x, *cache = self.model(
+            rhythms,
+            pitchs,
+            lifts,
+            articulations,
+            states,
+            context,
+            cache_len,
+            None,
+            *cache
         )
-        return out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations
+        return out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, *cache
 
 
 def convert_encoder() -> str:
@@ -110,46 +114,49 @@ def convert_decoder() -> str:
 
     # Create input data
     # Mask is not used since it caused problems with the tensor size
-    rhythms = torch.randint(0, config.num_rhythm_tokens, (1, 10)).long()
-    pitchs = torch.randint(0, config.num_pitch_tokens, (1, 10)).long()
-    lifts = torch.randint(0, config.num_lift_tokens, (1, 10)).long()
-    articulations = torch.randint(0, config.num_articulation_tokens, (1, 10)).long()
-    states = torch.randint(0, config.num_state_tokens, (1, 10)).long()
-    context = torch.randn((1, 1281, config.decoder_dim)).float()
+    kv_cache, kv_input_names, kv_output_names, dynamic_axes, cache_length = init_cache()
+    rhythms = torch.randint(0, config.num_rhythm_tokens, (1, 1)).long()
+    pitchs = torch.randint(0, config.num_pitch_tokens, (1, 1)).long()
+    lifts = torch.randint(0, config.num_lift_tokens, (1, 1)).long()
+    articulations = torch.randint(0, config.num_articulation_tokens, (1, 1)).long()
+    states = torch.randint(0, config.num_state_tokens, (1, 1)).long()
+    cache_len = torch.tensor([cache_length]).long()
+    cache = kv_cache
+    context = torch.randn((1, 1281, 312)).float()
 
-    dynamic_axes = {
-        "rhythms": {0: "batch_size", 1: "input_seq_len"},
-        "pitchs": {0: "batch_size", 1: "input_seq_len"},
-        "lifts": {0: "batch_size", 1: "input_seq_len"},
-        "articulations": {0: "batch_size", 1: "input_seq_len"},
-        "states": {0: "batch_size", 1: "input_seq_len"},
-        "context": {0: "batch_size"},
-        "out_rhythms": {0: "batch_size", 1: "output_seq_len"},
-        "out_pitchs": {0: "batch_size", 1: "output_seq_len"},
-        "out_lifts": {0: "batch_size", 1: "output_seq_len"},
-        "out_articulations": {0: "batch_size", 1: "output_seq_len"},
-        "out_positions": {0: "batch_size", 1: "output_seq_len"},
-    }
+    dynamic_axes["context"] = {1: "cache_exists"}
 
     torch.onnx.export(
         wrapped_model,
-        (rhythms, pitchs, lifts, articulations, states, context),
+        (rhythms, pitchs, lifts, articulations, states, context, cache_len, *cache),
         path_out,
-        input_names=["rhythms", "pitchs", "lifts", "articulations", "states", "context"],
+        input_names=["rhythms", "pitchs", "lifts", "articulations", "states", "context", "cache_len", *kv_input_names],
         output_names=[
             "out_rhythms",
             "out_pitchs",
             "out_lifts",
             "out_positions",
             "out_articulations",
+            *kv_output_names
         ],
         dynamic_axes=dynamic_axes,
-        opset_version=17,
+        opset_version=18,
         do_constant_folding=True,
         export_params=True,
     )
     return path_out
 
+def init_cache(cache_len=0):
+    cache = []
+    input_names = []    
+    output_names = []
+    dynamic = {}
+    for i in range(32):
+        cache.append(torch.zeros((1, 8, cache_len, 64), dtype=torch.float32))
+        input_names.append(f"cache_in{i}")
+        output_names.append(f"cache_out{i}")
+        dynamic[f"cache_in{i}"] = {2: "seq_len"}
+    return cache, input_names, output_names, dynamic, cache_len
 
 def convert_segnet() -> str:
     """

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -9,7 +9,7 @@ from training.architecture.segmentation.model import create_segnet  # type: igno
 from training.architecture.transformer.decoder import (
     ScoreTransformerWrapper,
     get_score_wrapper,
-    init_cache
+    init_cache,
 )
 from training.architecture.transformer.encoder import get_encoder
 
@@ -28,18 +28,12 @@ class DecoderWrapper(torch.nn.Module):
         states: torch.Tensor,
         context: torch.Tensor,
         cache_len: torch.Tensor,
-        *cache: torch.Tensor
+        *cache: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, _x, *cache = self.model(
-            rhythms,
-            pitchs,
-            lifts,
-            articulations,
-            states,
-            context,
-            cache_len,
-            None,
-            cache=cache
+        out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, _x, *cache = (
+            self.model(
+                rhythms, pitchs, lifts, articulations, states, context, cache_len, None, cache=cache
+            )
         )
         return out_rhythms, out_pitchs, out_lifts, out_positions, out_articulations, *cache
 
@@ -131,14 +125,23 @@ def convert_decoder() -> str:
         wrapped_model,
         (rhythms, pitchs, lifts, articulations, states, context, cache_len, *cache),
         path_out,
-        input_names=["rhythms", "pitchs", "lifts", "articulations", "states", "context", "cache_len", *kv_input_names],
+        input_names=[
+            "rhythms",
+            "pitchs",
+            "lifts",
+            "articulations",
+            "states",
+            "context",
+            "cache_len",
+            *kv_input_names,
+        ],
         output_names=[
             "out_rhythms",
             "out_pitchs",
             "out_lifts",
             "out_positions",
             "out_articulations",
-            *kv_output_names
+            *kv_output_names,
         ],
         dynamic_axes=dynamic_axes,
         opset_version=18,
@@ -146,6 +149,7 @@ def convert_decoder() -> str:
         export_params=True,
     )
     return path_out
+
 
 def convert_segnet() -> str:
     """

--- a/validation/symbol_error_rate_torch.py
+++ b/validation/symbol_error_rate_torch.py
@@ -136,7 +136,7 @@ def main() -> None:
     args = parser.parse_args()
 
     script_location = os.path.dirname(os.path.realpath(__file__))
-    data_set_location = os.path.join(script_location, "..", "datasets")
+    data_set_location = os.path.abspath(os.path.join(script_location, "..", "datasets"))
     validation_data_set_location = os.path.join(data_set_location, "validation")
     download_path = os.path.join(data_set_location, "validation.zip")
     download_url = (
@@ -146,7 +146,7 @@ def main() -> None:
         try:
             eprint("Downloading validation data set")
             download_utils.download_file(download_url, download_path)
-            download_utils.unzip_file(download_path, data_set_location)
+            download_utils.unzip_file(download_path, validation_data_set_location)
         finally:
             if os.path.exists(download_path):
                 os.remove(download_path)


### PR DESCRIPTION
Hey!
This PR introduces KV Cache for homr's decoder, resulting in significant performance improvements (around 2x faster).

 ### Details on the Implementation
Setting `return_hiddens=True` returns a `LayerIntermediates` object containing the KV cache. Since ONNX can't output  custom objects, we first need to extract the `kv_cache tensors`. This is done in the `ScoreTransformerWrapper`.
- First inference step: Input empty `kv_cache tensors` with `shape=(1,8,0,64)`. 
- Not-first inference step: Rebuild the `LayerIntermediates` object from the `kv_cache tensors` of the prior inference step. Reshaping the context tensor is - in contrast to x_transformers - not done within the onnx model, but in the `ScoreDecoder` because I had problems with onnx treating the if-statements as constants. 
Therefore I slightly modified x_transformer's `AttentionLayers.forward` method.


### Important things to note
- I used `x_transformers==2.4.9` (same as pyproject.toml) instead of `x_transformers==2.7.6` (used in poetry.lock)
- custom_x_transformer.py has been excluded from type_checking (I want to change as little as possible)
- Training has not been tested
- The decoder’s dynamic batch size was removed because it is not used
- This should not influence homr's quality: SER is at 35%
- The new models can be found [here](https://github.com/aicelen/homr/releases/tag/v0.4.0)