### PR TITLE
Feature/speed up preprocessing

### DIFF
--- a/homr/color_adjust.py
+++ b/homr/color_adjust.py
@@ -27,7 +27,7 @@ def get_dominant_color(gray_scale: NDArray, color_range: range, default: int | N
 
 
 def apply_clahe(channel: NDArray) -> NDArray:
-    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    clahe = cv2.createCLAHE(clipLimit=1.0, tileGridSize=(8, 8))
     return clahe.apply(channel)
 
 
@@ -84,7 +84,7 @@ def color_adjust(image: NDArray, block_size: int) -> tuple[NDArray, NDArray]:
     try:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         image, background = remove_background_from_channel(image, block_size)
-        return cv2.cvtColor(apply_clahe(image), cv2.COLOR_GRAY2BGR), background
+        return apply_clahe(image), background
     except Exception as e:
         eprint(e)
         return image, image

--- a/homr/main.py
+++ b/homr/main.py
@@ -284,7 +284,7 @@ def detect_staffs_in_image(
 
     debug.write_all_bounding_boxes_alternating_colors("notes", multi_staffs, notes)
 
-    return multi_staffs, predictions.original, debug, title_future
+    return multi_staffs, predictions.preprocessed, debug, title_future
 
 
 def get_all_image_files_in_folder(folder: str) -> list[str]:

--- a/homr/segmentation/inference_segnet.py
+++ b/homr/segmentation/inference_segnet.py
@@ -119,6 +119,7 @@ def inference(
     model = Segnet(use_gpu_inference)
     data = []
     batch = []
+    image_org = cv2.cvtColor(image_org, cv2.COLOR_GRAY2BGR)
     image = np.transpose(image_org, (2, 0, 1)).astype(np.float32)
     for y_loop in range(0, image.shape[1], step_size):
         if y_loop + win_size > image.shape[1]:

--- a/homr/transformer/staff2score.py
+++ b/homr/transformer/staff2score.py
@@ -1,7 +1,6 @@
 import os
 from time import perf_counter
 
-import cv2
 import numpy as np
 
 from homr.simple_logging import eprint
@@ -31,7 +30,6 @@ class Staff2Score:
         """
         Inference an image (NDArray) using Tromr.
         """
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         x = _transform(image=image)
 
         t0 = perf_counter()


### PR DESCRIPTION
It seems that we can skip some of the preprocessing steps to speed up the processing.

Before, we essentially had three steps:

1. CLAHE on the whole image with a clip limit of 2
2. fastNlMeansDenoising on each individual staff image
3. Another CLAHE on each staff image with a clip limit of 1

My impression is that the denoising mainly removes noise which was amplified by the first CLAHE step. Instead of the three steps, running a single CLAHE on the whole image with a smaller clip limit (also 1) gives the same quality of results.

In addition, this PR removes some cvtColor calls and most of the code now works on grayscale images - with the noticeable exception that the segmentation inference requires a matrix with 3 colors.