### PR TITLE
Fix Quantization

### DIFF
--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -9,7 +9,7 @@ from training.onnx.convert import (
     convert_encoder,
     convert_segnet,
 )
-from training.onnx.quantization import quantization_fp16
+from training.onnx.quantization import quantization_fp16, quantization_int8
 from training.onnx.simplify import main as simplify_onnx_model
 from training.onnx.split_weights import split_weights
 
@@ -40,7 +40,8 @@ def convert_all() -> None:
     # FP16 slowed inference speed down (CPU).
     path_to_decoder_fp16 = quantization_fp16(path_to_decoder, config.filepaths.decoder_path_fp16)
     print(path_to_decoder_fp16)
-
+    path_to_decoder_int8 = quantization_int8(path_to_decoder, config.filepaths.decoder_path)
+    print(path_to_decoder_int8)
     os.remove("decoder_weights.pt")
     os.remove("encoder_weights.pt")
 

--- a/training/onnx/quantization.py
+++ b/training/onnx/quantization.py
@@ -8,9 +8,7 @@ from onnxruntime.quantization.shape_inference import quant_pre_process
 from homr.simple_logging import eprint
 
 
-def quantization_int8(
-    model_path: str, out_path: str | None = None, preprocess: bool = True
-) -> None:
+def quantization_int8(model_path: str, out_path: str | None = None, preprocess: bool = True) -> str:
     """
     Dynamic Quantization of an onnx model to int8
     Args:
@@ -30,9 +28,10 @@ def quantization_int8(
             "model_preprocessed.onnx", out_path, weight_type=QuantType.QInt8
         )  # Quint8 is slower on x86-64
     else:
-        quantize_dynamic(model_path, out_path, weight_type=QuantType.QUInt8)
+        quantize_dynamic(model_path, out_path, weight_type=QuantType.QInt8)
 
     os.remove("model_preprocessed.onnx")
+    return out_path
 
 
 def quantization_fp16(model_path: str, out_path: str | None = None) -> str:

--- a/validation/symbol_error_rate_torch.py
+++ b/validation/symbol_error_rate_torch.py
@@ -1,8 +1,8 @@
 import argparse
 import os
 from pathlib import Path
-from typing import Any
 from time import perf_counter
+from typing import Any
 
 import cv2
 import editdistance
@@ -26,6 +26,7 @@ def calc_symbol_error_rate_for_list(
     model: Any
     if onnx:
         from homr.transformer.staff2score import Staff2Score as Staff2ScoreOnnx
+
         config = ConfigTorch()
         config.use_gpu_inference = use_gpu
         model = Staff2ScoreOnnx(config)
@@ -47,14 +48,14 @@ def calc_symbol_error_rate_for_list(
     i = 0
     total = len(dataset)
     interesting_results: list[tuple[str, str]] = []
-    inference_time = 0
+    inference_time = 0.0
     for sample in dataset:
         img_path, token_path = sample.strip().split(",")
         expected = read_tokens(token_path)
         image = cv2.imread(img_path)
-        image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         if image is None:
             raise ValueError("Failed to read " + img_path)
+        image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         t0 = perf_counter()
         actual: list[EncodedSymbol] = model.predict(image)
         inference_time += perf_counter() - t0


### PR DESCRIPTION
This reintroduces int8 quantization for the decoder to shrink it down to 23MB and improve performance by around 10% (SER stayed at 24% so there's no quality degradation).

This also fixes symbol_error_rate_torch.py not working due to missing grey scale conversion. I also added time measurement and the force gpu option we already have for normal inference.

@liebharc Could you just take a quick look at this if the changes are fine for you (I think you don't need to test anything as this is mainly a fix)? I'll than merge this and upload the quantized decoder to the releases page.