### PR TITLE
Repalce Unet++ with Unet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _build/
 *.pth
 *.onnx
 *.pt
+*.onnx.data
 
 # Byprodcuts of a training run
 /seg_unet.keras
@@ -41,6 +42,8 @@ _build/
 /*.musicxml
 /testdata
 /examples
+/canon
+*_try_*
 
 # WSL
 *Zone.Identifier

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented here.
 
 - **Greatly improved GPU inference**.
   Big thanks again to [@aicelen](https://github.com/aicelen) for the contribution!
+- **Faster Segmentation model**
 
 ### Changed
 

--- a/homr/constants.py
+++ b/homr/constants.py
@@ -67,7 +67,7 @@ image_noise_limit = 50
 
 staff_position_tolerance = 50
 
-max_angle_for_lines_to_be_parallel = 5
+max_angle_for_lines_to_be_parallel = 10
 
 
 NOTEHEAD_SIZE_RATIO = 1.285714  # width/height

--- a/homr/model.py
+++ b/homr/model.py
@@ -395,6 +395,7 @@ class Staff(DebugDrawable):
     ) -> "Staff":
         copy = Staff([point.transform_coordinates(transformation) for point in self.grid])
         copy.symbols = [symbol.transform_coordinates(transformation) for symbol in self.symbols]
+        copy.is_grandstaff = self.is_grandstaff
         return copy
 
 

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -3,11 +3,11 @@ import os
 script_location = os.path.dirname(os.path.realpath(__file__))
 
 segnet_path_onnx = os.path.join(
-    script_location, "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7.onnx"
+    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
 )
 
 segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7_fp16.onnx"
+    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714_fp16.onnx"
 )
 
 segnet_path_torch = os.path.join(
@@ -15,7 +15,7 @@ segnet_path_torch = os.path.join(
     "training",
     "architecture",
     "segmentation",
-    "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7.pth",
+    "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.pth",
 )
 
 segnet_version = os.path.basename(segnet_path_onnx).split("_")[1]

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -2,20 +2,18 @@ import os
 
 script_location = os.path.dirname(os.path.realpath(__file__))
 
-segnet_path_onnx = os.path.join(
-    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
-)
+model_name = "segnet_308-3296ccd40960f90ca6ab9c035cca945675d30a0f"
 
-segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714_fp16.onnx"
-)
+segnet_path_onnx = os.path.join(script_location, f"{model_name}.onnx")
+
+segnet_path_onnx_fp16 = os.path.join(script_location, f"{model_name}_fp16.onnx")
 
 segnet_path_torch = os.path.join(
     os.getcwd(),
     "training",
     "architecture",
     "segmentation",
-    "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.pth",
+    f"{model_name}.pth",
 )
 
 segnet_version = os.path.basename(segnet_path_onnx).split("_")[1]

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -3,11 +3,11 @@ import os
 script_location = os.path.dirname(os.path.realpath(__file__))
 
 segnet_path_onnx = os.path.join(
-    script_location, "segnet_155-1240eedca553155b3c75fc9c7f643465383430a0.onnx"
+    script_location, "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64.onnx"
 )
 
 segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_155-1240eedca553155b3c75fc9c7f643465383430a0_fp16.onnx"
+    script_location, "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64_fp16.onnx"
 )
 
 segnet_path_torch = os.path.join(
@@ -15,7 +15,7 @@ segnet_path_torch = os.path.join(
     "training",
     "architecture",
     "segmentation",
-    "segnet_155-1240eedca553155b3c75fc9c7f643465383430a0.pth",
+    "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64.pth",
 )
 
 segnet_version = os.path.basename(segnet_path_onnx).split("_")[1]

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -3,11 +3,11 @@ import os
 script_location = os.path.dirname(os.path.realpath(__file__))
 
 segnet_path_onnx = os.path.join(
-    script_location, "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64.onnx"
+    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
 )
 
 segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64_fp16.onnx"
+    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
 )
 
 segnet_path_torch = os.path.join(
@@ -15,7 +15,7 @@ segnet_path_torch = os.path.join(
     "training",
     "architecture",
     "segmentation",
-    "segnet_301-f1c2688efe7efb0aace96b06364022baf5c65e64.pth",
+    "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.pth",
 )
 
 segnet_version = os.path.basename(segnet_path_onnx).split("_")[1]

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -7,7 +7,7 @@ segnet_path_onnx = os.path.join(
 )
 
 segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
+    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714_fp16.onnx"
 )
 
 segnet_path_torch = os.path.join(

--- a/homr/segmentation/config.py
+++ b/homr/segmentation/config.py
@@ -3,11 +3,11 @@ import os
 script_location = os.path.dirname(os.path.realpath(__file__))
 
 segnet_path_onnx = os.path.join(
-    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.onnx"
+    script_location, "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7.onnx"
 )
 
 segnet_path_onnx_fp16 = os.path.join(
-    script_location, "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714_fp16.onnx"
+    script_location, "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7_fp16.onnx"
 )
 
 segnet_path_torch = os.path.join(
@@ -15,7 +15,7 @@ segnet_path_torch = os.path.join(
     "training",
     "architecture",
     "segmentation",
-    "segnet_303-71bee8fac626ac28e8d17ddc33138421edc8e714.pth",
+    "segnet_306-da10d8ae04b8acb8862f3a77ce660ef744026fb7.pth",
 )
 
 segnet_version = os.path.basename(segnet_path_onnx).split("_")[1]

--- a/homr/staff_detection.py
+++ b/homr/staff_detection.py
@@ -344,12 +344,12 @@ def find_staff_anchors(
         # Therefore we try to detect them at the left and right side of the symbol as well.
         if are_clefs:
             adjacent = [
+                center_symbol.move_to_x_horizontal_by(-10),
                 center_symbol,
-                center_symbol.move_to_x_horizontal_by(50),
-                center_symbol,
-                center_symbol.move_to_x_horizontal_by(100),
-                center_symbol,
-                center_symbol.move_to_x_horizontal_by(150),
+                center_symbol.move_to_x_horizontal_by(10),
+                center_symbol.move_to_x_horizontal_by(30),
+                center_symbol.move_to_x_horizontal_by(60),
+                center_symbol.move_to_x_horizontal_by(80),
             ]
         else:
             adjacent = [

--- a/homr/staff_parsing_tromr.py
+++ b/homr/staff_parsing_tromr.py
@@ -16,4 +16,7 @@ def predict_best(org_image: NDArray, staff: Staff, config: Config) -> list[Encod
     if inference is None:
         inference = Staff2Score(config)
 
-    return inference.predict(org_image)
+    result = inference.predict(org_image)
+    if staff.is_grandstaff:
+        return result
+    return [r for r in result if r.position != "lower"]

--- a/training/architecture/segmentation/model.py
+++ b/training/architecture/segmentation/model.py
@@ -15,7 +15,7 @@ class CamVidModel(pl.LightningModule):
 
     def __init__(
         self,
-        arch: str = "UnetPlusPlus",
+        arch: str = "Unet",
         encoder_name: str = "resnet18",
         in_channels: int = 3,
         out_classes: int = 0,

--- a/training/datasets/music_xml_parser.py
+++ b/training/datasets/music_xml_parser.py
@@ -217,31 +217,36 @@ class TokensPart:
 
     def append_symbol(self, symbol: EncodedSymbol) -> None:
         if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
+            eprint("Expected to get clefs as first symbol")
+            return
         self.current_measure.append_symbol(symbol)
 
     def append_rest(
         self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
     ) -> None:
         if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
+            eprint("Expected to get clefs as first symbol")
+            return
         self.current_measure.append_rest(staff, is_chord, duration, invisible, symbol)
 
     def append_note(
         self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
     ) -> None:
         if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
+            eprint("Expected to get clefs as first symbol")
+            return
         self.current_measure.append_note(staff, is_chord, duration, invisible, symbol)
 
     def append_position_change(self, duration: int) -> None:
         if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
+            eprint("Expected to get clefs as first symbol")
+            return
         self.current_measure.append_position_change(duration)
 
     def on_end_of_measure(self) -> None:
         if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
+            eprint("Expected to get clefs as first symbol")
+            return
 
         self.measures.append(self.current_measure.complete_measure())
         self.current_measure = TokensMeasure()

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -202,7 +202,7 @@ def convert_segnet() -> str:
         model,
         sample_inputs,  # type: ignore
         path_out,
-        opset_version=17,
+        opset_version=18,
         do_constant_folding=True,
         input_names=["input"],
         output_names=["output"],

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -209,4 +209,4 @@ def convert_segnet() -> str:
         dynamo=True,
         external_data=False,
     )
-    return f"{os.path.splitext(segnet_path_torch)[0]}.onnx"
+    return path_out

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -3,7 +3,7 @@ import os
 import torch
 from torch.export import Dim
 
-from homr.segmentation.config import segnet_path_torch
+from homr.segmentation.config import segnet_path_torch, segnet_path_onnx
 from homr.simple_logging import eprint
 from homr.transformer.configs import Config
 from training.architecture.segmentation.model import create_segnet  # type: ignore
@@ -183,10 +183,7 @@ def convert_segnet() -> str:
     """
     Converts the segnet model to onnx.
     """
-
-    dir_path = os.path.dirname(segnet_path_torch)
-    filename = os.path.splitext(os.path.basename(segnet_path_torch))[0]
-    path_out = os.path.join(dir_path, f"{filename}.onnx")
+    path_out = segnet_path_onnx
 
     if os.path.exists(path_out):
         eprint(path_out, "is already present")
@@ -210,5 +207,6 @@ def convert_segnet() -> str:
         # dyamic axes are required for dynamic batch_size
         dynamic_shapes={"image": (Dim("batch_size"), 3, 320, 320)},
         dynamo=True,
+        external_data=False
     )
     return f"{os.path.splitext(segnet_path_torch)[0]}.onnx"

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -194,7 +194,7 @@ def convert_segnet() -> str:
     model.eval()
 
     # Input dimension is 1x3x320x320
-    sample_inputs = torch.randn(8, 3, 320, 320)
+    sample_inputs = torch.randn(8, 1, 320, 320)
 
     torch.onnx.export(
         model,
@@ -205,7 +205,7 @@ def convert_segnet() -> str:
         input_names=["input"],
         output_names=["output"],
         # dyamic axes are required for dynamic batch_size
-        dynamic_shapes={"image": (Dim("batch_size"), 3, 320, 320)},
+        dynamic_shapes={"image": (Dim("batch_size"), 1, 320, 320)},
         dynamo=True,
         external_data=False,
     )

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -3,7 +3,7 @@ import os
 import torch
 from torch.export import Dim
 
-from homr.segmentation.config import segnet_path_torch, segnet_path_onnx
+from homr.segmentation.config import segnet_path_onnx, segnet_path_torch
 from homr.simple_logging import eprint
 from homr.transformer.configs import Config
 from training.architecture.segmentation.model import create_segnet  # type: ignore
@@ -207,6 +207,6 @@ def convert_segnet() -> str:
         # dyamic axes are required for dynamic batch_size
         dynamic_shapes={"image": (Dim("batch_size"), 3, 320, 320)},
         dynamo=True,
-        external_data=False
+        external_data=False,
     )
     return f"{os.path.splitext(segnet_path_torch)[0]}.onnx"

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -1,6 +1,7 @@
 import os
 
 import torch
+from torch.export import Dim
 
 from homr.segmentation.config import segnet_path_torch
 from homr.simple_logging import eprint
@@ -196,7 +197,7 @@ def convert_segnet() -> str:
     model.eval()
 
     # Input dimension is 1x3x320x320
-    sample_inputs = torch.randn(1, 3, 320, 320)
+    sample_inputs = torch.randn(8, 3, 320, 320)
 
     torch.onnx.export(
         model,
@@ -207,6 +208,7 @@ def convert_segnet() -> str:
         input_names=["input"],
         output_names=["output"],
         # dyamic axes are required for dynamic batch_size
-        dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},
+        dynamic_shapes={"image": (Dim("batch_size"), 3, 320, 320)},
+        dynamo=True,
     )
     return f"{os.path.splitext(segnet_path_torch)[0]}.onnx"

--- a/training/onnx/convert.py
+++ b/training/onnx/convert.py
@@ -194,7 +194,7 @@ def convert_segnet() -> str:
     model.eval()
 
     # Input dimension is 1x3x320x320
-    sample_inputs = torch.randn(8, 1, 320, 320)
+    sample_inputs = torch.randn(8, 3, 320, 320)
 
     torch.onnx.export(
         model,
@@ -205,7 +205,7 @@ def convert_segnet() -> str:
         input_names=["input"],
         output_names=["output"],
         # dyamic axes are required for dynamic batch_size
-        dynamic_shapes={"image": (Dim("batch_size"), 1, 320, 320)},
+        dynamic_shapes={"image": (Dim("batch_size"), 3, 320, 320)},
         dynamo=True,
         external_data=False,
     )

--- a/training/onnx/main.py
+++ b/training/onnx/main.py
@@ -14,16 +14,23 @@ from training.onnx.simplify import main as simplify_onnx_model
 from training.onnx.split_weights import split_weights
 
 
-def convert_all() -> None:
-    # Warnings might occur
+def convert_segnet_quant() -> None:
+    """
+    Converts and Quantizes the Segnet.
+    """
     path_to_segnet = convert_segnet()
     simplify_onnx_model(path_to_segnet)
     print(path_to_segnet)
     path_to_segnet_fp16 = quantization_fp16(path_to_segnet, segnet_path_onnx_fp16)
     print(path_to_segnet_fp16)
 
+
+def convert_transformer_quant() -> None:
+    """
+    Converts and Quantizes the Transformer (results in an encoder and a decoder).
+    """
     config = Config()
-    split_weights(config.filepaths.checkpoint)  # Make sure to the filepath of the transformer!
+    split_weights(config.filepaths.checkpoint)
     path_to_encoder = convert_encoder()
     simplify_onnx_model(path_to_encoder)
     print(path_to_encoder)
@@ -48,5 +55,4 @@ def convert_all() -> None:
 
 if __name__ == "__main__":
     # Converts pytorch models used by homr to onnx
-
-    convert_all()
+    convert_segnet_quant()

--- a/training/segmentation/train.py
+++ b/training/segmentation/train.py
@@ -96,7 +96,7 @@ class SegmentationBaseDataset(BaseDataset[tuple[NDArray, NDArray]]):
             image, mask = sample["image"], sample["mask"]
         # image = image.transpose(2, 0, 1)
         image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
-        image = np.array([image, image, image])
+        image = np.array([image])
         return image, mask
 
     def _get_patch(self, image: NDArray, x: int, y: int, pad_value: int) -> NDArray:
@@ -331,7 +331,7 @@ def train_segnet(visualize: bool = False) -> None:
 
     model = create_segnet()
 
-    trainer = pl.Trainer(max_epochs=3, log_every_n_steps=1)
+    trainer = pl.Trainer(max_epochs=2, log_every_n_steps=1)
 
     trainer.fit(
         model,

--- a/training/segmentation/train.py
+++ b/training/segmentation/train.py
@@ -96,7 +96,7 @@ class SegmentationBaseDataset(BaseDataset[tuple[NDArray, NDArray]]):
             image, mask = sample["image"], sample["mask"]
         # image = image.transpose(2, 0, 1)
         image = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
-        image = np.array([image])
+        image = np.array([image, image, image])
         return image, mask
 
     def _get_patch(self, image: NDArray, x: int, y: int, pad_value: int) -> NDArray:
@@ -331,7 +331,7 @@ def train_segnet(visualize: bool = False) -> None:
 
     model = create_segnet()
 
-    trainer = pl.Trainer(max_epochs=2, log_every_n_steps=1)
+    trainer = pl.Trainer(max_epochs=3, log_every_n_steps=1)
 
     trainer.fit(
         model,

--- a/training/segmentation/train.py
+++ b/training/segmentation/train.py
@@ -226,7 +226,7 @@ class AddGrayGradient(A.ImageOnlyTransform):
 def get_training_augmentation() -> Any:
     train_transform = [
         AddGrayGradient(alpha=0.4, direction="vertical", p=1.0),
-        A.HorizontalFlip(p=0.5),
+        A.HorizontalFlip(p=0.2),
         A.ShiftScaleRotate(scale_limit=0.5, rotate_limit=0, shift_limit=0.1, p=1, border_mode=0),
         A.GaussNoise(p=0.2),
         A.Perspective(p=0.5),
@@ -241,8 +241,9 @@ def get_training_augmentation() -> Any:
         A.OneOf(
             [
                 A.Sharpen(p=1),
-                A.Blur(blur_limit=3, p=1),
+                A.Blur(blur_limit=[3, 7], p=1),
                 A.MotionBlur(blur_limit=3, p=1),
+                A.Defocus(radius=(3, 7), alias_blur=(0.1, 0.5), p=1.0),
             ],
             p=0.9,
         ),

--- a/training/segmentation/train.py
+++ b/training/segmentation/train.py
@@ -299,8 +299,8 @@ def train_segnet(visualize: bool = False) -> None:
 
     validation_dataset = D2DenseDataset(val_images, augmentation=None)
 
-    train_loader = DataLoader(train_dataset, batch_size=24, shuffle=False, num_workers=4)
-    validation_loader = DataLoader(validation_dataset, batch_size=24, shuffle=False, num_workers=4)
+    train_loader = DataLoader(train_dataset, batch_size=32, shuffle=False, num_workers=6)
+    validation_loader = DataLoader(validation_dataset, batch_size=32, shuffle=False, num_workers=6)
 
     model = create_segnet()
 

--- a/training/segmentation/train.py
+++ b/training/segmentation/train.py
@@ -312,7 +312,9 @@ def train_segnet(visualize: bool = False) -> None:
     dense_root = os.path.join(dataset_root, "ds2_dense")
 
     run_id = get_run_id()
-    model_destination = os.path.join(git_root, "homr", "segmentation", f"segnet_{run_id}.pth")
+    model_destination = os.path.join(
+        git_root, "training", "architecture", "segmentation", f"segnet_{run_id}.pth"
+    )
     eprint("Starting training of ", model_destination)
 
     images_dir = os.path.join(dense_root, "images")


### PR DESCRIPTION
Hey!
I experimented a bit with the Segnet.
I replaced the Unet++ with the simpler Unet architecture. The results seem promising (2x-3x faster; see the results on tabi.jpg below) but I don't have a set of images to test the segnet on. Do you have one?
Have you ever tried using the normal Unet or other more lightweight architectures?
Also it seems that replacing the resnet18 encoder (I tried mobilenetv3_small) is not worth it as it heavily degrades quality while only bringing small performance uplifts.

I marked this WIP as we first need to verify that there aren't any quality degradations.

Old Unet++
<img width="2400" height="1000" alt="unet++_segmentation" src="https://github.com/user-attachments/assets/5d78e002-72f1-4614-8b08-cbeab2b413c1" />

New Unet
<img width="2400" height="1000" alt="unet_segmentation" src="https://github.com/user-attachments/assets/7dd3dbc6-0010-490a-ad87-5b6f5bc935d4" />
