### PR TITLE
Link Andromr

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ processed using tools such as [musescore](https://musescore.com/).
 
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/liebharc/homr/blob/main/colab.ipynb)
 
+You might also want to check out [Andromr](https://github.com/aicelen/Andromr), an Android app for optical music recognition using homr.
+
 ## Prerequisites
 
 - Python 3.11


### PR DESCRIPTION
Hi!

Andromr is finally in the testing phase of the Play Store. Therefore I'd like to link Andromr in homr's readme.


I also investigated the scaling problem of the decoder. One problem is that we don't use any advanced operator fusion (e.g. MultiHeadAttention). The already existing transformer optimizer didn't work.
I "vibecoded" a prototype with Codex which improved performance (I think it decreased the time per token from 12ms to 8ms). I'd try to clean up the whole code and then make a PR (but that might take some more time). 

Also I took a deeper look why the model is faster with Flash Attention. The reason is not that the model actually uses FA but that the calculation of the Center of Attention (which we don't have when using FA) uses 3 Einsum nodes which are extremly slow (around 1ms per node). A possible solution would be to replace the node with a MatMul and a Transpose node, which actually worked, but the code is extremly bad (I also "vibecoded" that and it produced like 300 lines of really messy code).