### PR TITLE
Fix docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM python:3.11
 
 WORKDIR /app
 
+RUN apt update && apt install -y libgl1
+
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 RUN git clone https://github.com/liebharc/homr .


### PR DESCRIPTION
run docker build via [Dockerfile](https://github.com/liebharc/homr/blob/main/Dockerfile) and got this error
```
/root/.local/bin/poetry run homr -h

Traceback (most recent call last):
...(stacks)...
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```
so I think we can add `apt install libgl1` in the Dockerfile.
This PR Fixes #69
