### PR TITLE
Support Grandstaff Detection

### DIFF
--- a/homr/brace_dot_detection.py
+++ b/homr/brace_dot_detection.py
@@ -131,10 +131,12 @@ def _merge_multi_staff_if_they_share_a_staff(staffs: list[MultiStaff]) -> list[M
     return result
 
 
-def _create_grandstaffs(staffs: list[MultiStaff]) -> list[MultiStaff]:
+def _create_grandstaffs(
+    staffs: list[MultiStaff], brace_dot: list[RotatedBoundingBox]
+) -> list[MultiStaff]:
     if len(staffs) == 0:
         return staffs
-    return [s.create_grandstaffs() for s in staffs]
+    return [s.create_grandstaffs(brace_dot) for s in staffs]
 
 
 def find_braces_brackets_and_grand_staff_lines(
@@ -160,4 +162,4 @@ def find_braces_brackets_and_grand_staff_lines(
         if not any_connected_neighbor:
             result.append(MultiStaff([staff], []))
 
-    return _create_grandstaffs(_merge_multi_staff_if_they_share_a_staff(result))
+    return _create_grandstaffs(_merge_multi_staff_if_they_share_a_staff(result), brace_dot)

--- a/homr/constants.py
+++ b/homr/constants.py
@@ -71,3 +71,6 @@ max_angle_for_lines_to_be_parallel = 10
 
 
 NOTEHEAD_SIZE_RATIO = 1.285714  # width/height
+
+grandstaff_x_distance_threshold_factor = 5
+grandstaff_y_overlap_threshold_factor = 0.5

--- a/homr/model.py
+++ b/homr/model.py
@@ -419,30 +419,103 @@ class MultiStaff(DebugDrawable):
                 unique_connections.append(connection)
         return MultiStaff(unique_staffs, unique_connections)
 
-    def create_grandstaffs(self) -> "MultiStaff":
-        """
-        Blindly creates grandstaffs, by combining staff 0&1, 2&3, ...
-        for odd numbers of staffs the first staff will be a single staff
-        """
-        n = len(self.staffs)
-        if n == 0:
-            return self
+    """
+    rules to determain whether two staffs should be merged into a grandstaff by current brace:
+    1. x_distance: the left side of staff should be close enough
+       (within 5* the average unit size) to the brace symbol
+    2. y_overlap: the top and bottom of the brace symbol should overlap (at least 50% of) the staffs
+    return scores = y_overlap(higher the better) - x_distance(lower the better)
+    """
 
-        result = []
+    def _score_brace_with_staff_pair(
+        self, symbol: RotatedBoundingBox, upper_staff: Staff, lower_staff: Staff
+    ) -> float:
+        unit_size = float(np.median([upper_staff.average_unit_size, lower_staff.average_unit_size]))
+        x_distance_threshold = constants.grandstaff_x_distance_threshold_factor * unit_size
+        y_overlap_threshold = constants.grandstaff_y_overlap_threshold_factor * symbol.size[1]
+
+        symbol_min_x = symbol.center[0]
+        staff_min_x = min(upper_staff.min_x, lower_staff.min_x)
+        x_distance = abs(staff_min_x - symbol_min_x)
+
+        symbol_min_y = symbol.center[1] - symbol.size[1] / 2
+        symbol_max_y = symbol.center[1] + symbol.size[1] / 2
+        y_overlap = min(symbol_max_y, lower_staff.max_y) - max(symbol_min_y, upper_staff.min_y)
+
+        if (
+            x_distance < x_distance_threshold
+            and y_overlap > y_overlap_threshold
+            and y_overlap > x_distance
+        ):
+            return y_overlap - x_distance
+        else:
+            return 0
+
+    class GrandStaffPair:
+        def __init__(self, pair_index: list[int], score: float):
+            self.pair_index = pair_index
+            self.score = score
+
+        def get_score(self) -> float:
+            return self.score
+
+        def get_index(self) -> list[int]:
+            return self.pair_index
+
+        def __repr__(self) -> str:
+            return f"staff pair: {self.pair_index} with score: {self.score})"
+
+    def _select_grandstaffs(
+        self, brace_dot: list[RotatedBoundingBox]
+    ) -> list["MultiStaff.GrandStaffPair"]:
+        pair_scores: list[MultiStaff.GrandStaffPair] = []
+        # step1: we try each two staffs combination, like (0,1), (1,2), (2,3), ...
+        for i in range(len(self.staffs) - 1):
+            best_score = max(
+                (
+                    self._score_brace_with_staff_pair(symbol, self.staffs[i], self.staffs[i + 1])
+                    for symbol in brace_dot
+                ),
+            )
+            # step2: we try all braces for the current staff pair to see if there is a good match
+            if best_score > 0:
+                pair_scores.append(MultiStaff.GrandStaffPair([i, i + 1], best_score))
+
+        # step3: we can't simply return pair_scores, because some staff may be used more than once,
+        # like ([0,1], score=0.5), ([1,2], score=0.8)
+        # in this case, we only select highest score pair, which is ([1,2], score=0.8)
+        result: list[MultiStaff.GrandStaffPair] = []
+        used_staff_index: set[int] = set()
+        for pair in sorted(pair_scores, key=lambda pair: pair.get_score(), reverse=True):
+            if any(index in used_staff_index for index in pair.get_index()):
+                continue
+
+            result.append(pair)
+            used_staff_index.update(pair.get_index())
+
+        return result
+
+    def _merge_selected_pairs(self, pairs: list["MultiStaff.GrandStaffPair"]) -> list[Staff]:
+        result: list[Staff] = []
         i = 0
-
-        if n % 2 == 1:
-            result.append(self.staffs[0])
-            i = 1
-
-        while i + 1 < n:
-            result.append(self.staffs[i].merge(self.staffs[i + 1]))
-            i += 2
-
-        if i < n:
+        while i < len(self.staffs):
+            if any(i in pair.get_index() for pair in pairs):
+                result.append(self.staffs[i].merge(self.staffs[i + 1]))
+                i += 2
+                continue
+            # not grandstaff
             result.append(self.staffs[i])
+            i += 1
+        return result
 
-        return MultiStaff(result, self.connections)
+    def create_grandstaffs(self, brace_dot: list[RotatedBoundingBox]) -> "MultiStaff":
+        if len(self.staffs) < 2:
+            return self
+        pairs = self._select_grandstaffs(brace_dot)
+        if not pairs:
+            return self
+        merged_staffs = self._merge_selected_pairs(pairs)
+        return MultiStaff(merged_staffs, self.connections)
 
     def break_apart(self) -> list["MultiStaff"]:
         return [MultiStaff([staff], []) for staff in self.staffs]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -17,6 +17,29 @@ def make_connection(number: int) -> RotatedBoundingBox:
     return RotatedBoundingBox(rect, contours)
 
 
+def make_brace(
+    upper_staff_index: int,
+    lower_staff_index: int,
+    x_bias: float = 0.0,
+    y_bias: float = 0.0,
+) -> RotatedBoundingBox:
+    center_x = 0.0
+    min_y = upper_staff_index * 100
+    max_y = (
+        lower_staff_index * 100 + 40
+    )  # because one staff is 40px high and starts from n*100px, see def make_staff()
+    center_y = (min_y + max_y) / 2
+
+    center_x += x_bias
+    center_y += y_bias
+
+    width = 10.0
+    height = max_y - min_y
+    rect = ((center_x, center_y), (width, height), 0.0)
+    contours = np.empty((0, 0))
+    return RotatedBoundingBox(rect, contours)
+
+
 class TestModel(unittest.TestCase):
 
     def test_multi_staff_merge(self) -> None:
@@ -40,39 +63,30 @@ class TestModel(unittest.TestCase):
             [staff2.connections[0], staff2.connections[1], staff1.connections[0]],
         )
 
-    def test_create_grandstaffs_even(self) -> None:
-        staffs = [make_staff(i) for i in range(4)]
-        connections = [make_connection(i) for i in range(4)]
-        ms = MultiStaff(staffs, connections)
-
-        result = ms.create_grandstaffs()
-
-        self.assertEqual(len(result.staffs), 2)
-        self.assertEqual(result.staffs[0].min_y, staffs[0].min_y)
-        self.assertEqual(result.staffs[0].max_y, staffs[1].max_y)
-        self.assertEqual(result.staffs[1].min_y, staffs[2].min_y)
-        self.assertEqual(result.staffs[1].max_y, staffs[3].max_y)
-        self.assertEqual(result.connections, connections)
-
-    def test_create_grandstaffs_odd(self) -> None:
-        staffs = [make_staff(i) for i in range(5)]
-        connections = [make_connection(i) for i in range(5)]
-        ms = MultiStaff(staffs, connections)
-
-        result = ms.create_grandstaffs()
-
-        self.assertEqual(len(result.staffs), 3)
-        self.assertEqual(result.staffs[0].min_y, staffs[0].min_y)
-        self.assertEqual(result.staffs[0].max_y, staffs[0].max_y)
-        self.assertEqual(result.staffs[1].min_y, staffs[1].min_y)
-        self.assertEqual(result.staffs[1].max_y, staffs[2].max_y)
-        self.assertEqual(result.staffs[2].min_y, staffs[3].min_y)
-        self.assertEqual(result.staffs[2].max_y, staffs[4].max_y)
-        self.assertEqual(result.connections, connections)
-
     def test_create_grandstaffs_empty(self) -> None:
         ms = MultiStaff([], [])
 
-        result = ms.create_grandstaffs()
+        result = ms.create_grandstaffs([make_brace(0, 1)])
 
         self.assertIs(result, ms)
+
+    def test_create_grandstaffs(self) -> None:
+        ms = MultiStaff([make_staff(i) for i in range(4)], [])
+
+        result = ms._select_grandstaffs([make_brace(0, 1), make_brace(2, 3)])
+
+        self.assertEqual([pair.get_index() for pair in result], [[0, 1], [2, 3]])
+
+    def test_create_grandstaffs_overlapping(self) -> None:
+        ms = MultiStaff([make_staff(i) for i in range(4)], [])
+
+        result = ms._select_grandstaffs([make_brace(0, 1, x_bias=20.0), make_brace(1, 2)])
+
+        self.assertEqual([pair.get_index() for pair in result], [[1, 2]])
+
+    def test_create_grandstaffs_invalid_brace(self) -> None:
+        ms = MultiStaff([make_staff(i) for i in range(3)], [])
+
+        result = ms._select_grandstaffs([make_brace(0, 1, x_bias=500.0)])
+
+        self.assertEqual(result, [])


### PR DESCRIPTION
This PR implement grandstaff detection method proposed in #62 

- Use brace detections from the segmentation model.
- Match brace bounding boxes to staff vertical ranges.
- Derive stable pairing rules from brace-staff alignment instead of fixed ordering.

## Implementation

In detail, there are 3 steps:

1. we try each two staffs combination, like `(0,1), (1,2), (2,3)`, ...
2. for the current staff pair (like `(0,1)`), we try all braces to see if there is a good match. the pairing rules are:
    i. x_distance: the left side of staff should be close enough (within 5* the average unit size) to the brace symbol
    ii. y_overlap: the top and bottom of the brace symbol should overlap (at least 50% of) the staffs
    iii. final score = y_overlap(higher the better) - x_distance(lower the better)
3. consider some staff may be used more than once(like `([0,1], score=0.5), ([1,2], score=0.8)`), we only select highest score pair, which is `([1,2], score=0.8)`

## Test

- I have run `make test` and `make ci`, seems ok

- Also try `OdeToJoy.jpg` from #60 , and the new grandstaff detection is able to merge staff 2&3 into grandstaff 

former `test_create_grandstaffs_even/odd` are removed


