### PR TITLE
Add retry for download

### DIFF
--- a/homr/download_utils.py
+++ b/homr/download_utils.py
@@ -8,6 +8,20 @@ from homr.simple_logging import eprint
 
 
 def download_file(url: str, filename: str) -> None:
+    max_tries = 3
+    for i in range(max_tries):
+        try:
+            _download_file(url, filename)
+            return
+        except requests.exceptions.RequestException as e:
+            eprint(f"Error downloading file {url}: {e}. Retrying {i}/{max_tries}...")
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    raise Exception(f"Failed to download file {url}.")
+
+
+def _download_file(url: str, filename: str) -> None:
     response = requests.get(url, stream=True, timeout=5)
     total = int(response.headers.get("content-length", 0))
     totalMb = round(total / 1024 / 1024)

--- a/training/datasets/convert_lieder.py
+++ b/training/datasets/convert_lieder.py
@@ -454,7 +454,7 @@ def convert_lieder(only_recreate_token_files: bool = False) -> None:
     if not os.path.exists(musescore_path):
         eprint("Downloading MuseScore from https://musescore.org/")
         download_file(
-            "https://cdn.jsdelivr.net/musescore/v4.2.1/MuseScore-4.2.1.240230938-x86_64.AppImage",
+            "https://github.com/musescore/MuseScore/releases/download/v4.2.1/MuseScore-4.2.1.240230938-x86_64.AppImage",
             musescore_path,
         )
         os.chmod(musescore_path, stat.S_IXUSR)


### PR DESCRIPTION
This patch add retry for `def download_file()`
1. if some exception raises, we will retry for at most 3 times. exceptions can raise from:
  a. `requests.get(url)` : url inaccessible
  b. `response.iter_content` : download broken half way
2. if still unable to download, we will try a backup url, if exists. At present, `musescore` has a backup url.