### PR TITLE
ignore broken files in grandstaff dataset

### DIFF
--- a/training/datasets/convert_grandstaff.py
+++ b/training/datasets/convert_grandstaff.py
@@ -120,6 +120,9 @@ def _convert_tokens_and_image(path: Path) -> tuple[Path, str]:
 
 
 def _filter_out_known_bad_ones(path: Path) -> bool:
+    if path.name.startswith("._"):
+        return False
+
     # These images contain to meaningful data or have
     # artifacts like large black areas
     bad_files = {


### PR DESCRIPTION
In dataset grandstaff, there are some broken files:
```
find ./datasets/grandstaff/ -name "\.*"
./datasets/grandstaff/chopin/mazurkas/mazurka41-2/._maj3_down_m-25-29.bekrn
./datasets/grandstaff/chopin/mazurkas/mazurka06-1/._maj2_down_m-0-3_distorted.jpg
./datasets/grandstaff/chopin/mazurkas/mazurka30-4/._original_m-113-117.bekrn
./datasets/grandstaff/hummel/preludes/prelude67-19/._original_m-6-11.jpg
./datasets/grandstaff/hummel/preludes/prelude67-01/._maj2_down_m-4-7.bekrn
./datasets/grandstaff/hummel/preludes/prelude67-01/._maj2_down_m-4-7.krn
./datasets/grandstaff/hummel/preludes/prelude67-01/._maj2_up_m-4-7.bekrn
./datasets/grandstaff/mozart/piano-sonatas/sonata03-1/._maj2_up_m-16-21.bekrn
./datasets/grandstaff/mozart/piano-sonatas/sonata15-2/._maj3_down_m-73-77.bekrn
./datasets/grandstaff/mozart/piano-sonatas/sonata08-3/._maj2_down_m-113-117.jpg
./datasets/grandstaff/mozart/piano-sonatas/sonata08-3/._maj2_down_m-105-109_distorted.jpg
./datasets/grandstaff/mozart/piano-sonatas/sonata12-3/._maj2_down_m-169-172_distorted.jpg
./datasets/grandstaff/mozart/piano-sonatas/sonata06-3e/._min3_down_m-12-16.bekr
```
I have manually tested, these files are meaningless, and `convert_grandstaff.py` can't read it either: 
`Failed to convert  /root/homr/datasets/grandstaff/hummel/preludes/prelude67-01/._maj2_down_m-4-7.krn 'utf-8' codec can't decode byte 0xb0 in position 45: invalid start byte`

So let's ignore them