### PR TITLE
Support Multi-GPU Training

### DIFF
--- a/Training.md
+++ b/Training.md
@@ -38,6 +38,12 @@ Finally, start the training itself with: `training/train.py transformer`.
 You can check the log and see number of training files to be 197k: `Total number of training files to choose from 197032`
 This takes around 2–4 days.
 
+Distributed Training:
+
+- Distributed training supports single-machine, multi-GPU setups. Using 4 GPUs as an example, run: `CUDA_VISIBLE_DEVICES=0,1,2,3 poetry run torchrun --standalone --nnodes=1 --nproc_per_node=4 training/train.py transformer`
+- Dataset generation and model loading/saving are handled by rank0.
+- It is recommended to use 2 or 4 GPUs to keep training consistent with single-GPU training. For other GPU counts, you need to manually adjust the `gradient_accumulation_steps` parameter. Multi-node, multi-GPU training is theoretically supported, but has not been tested in practice.
+
 ## Results
 
 The `homr` pipeline is a two-step system consisting of **staff detection (segnet)** followed by **music transcription (TrOmr transformer)**.  

--- a/training/transformer/distribute.py
+++ b/training/transformer/distribute.py
@@ -1,0 +1,46 @@
+# S101: assert is intentional for distributed init preconditions
+# flake8: noqa: S101
+
+import os
+
+import torch
+
+
+class Distribute:
+    def __init__(self) -> None:
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+        if world_size <= 1:
+            self.enabled = False
+            return
+
+        assert torch.cuda.is_available()
+        assert torch.distributed.is_available()
+        assert not torch.distributed.is_initialized()
+
+        local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        torch.cuda.set_device(local_rank)
+        self._device = torch.device(f"cuda:{local_rank}")
+        torch.distributed.init_process_group(backend="nccl", device_id=self._device)
+        self.enabled = True
+        self.rank = torch.distributed.get_rank()
+        self.world_size = world_size
+
+    def barrier(self) -> None:
+        if not self.enabled:
+            return
+        torch.distributed.barrier(device_ids=[self._device.index])
+
+    def destroy(self) -> None:
+        if not self.enabled:
+            return
+        torch.distributed.destroy_process_group()
+
+    def is_rank0(self) -> bool:
+        if not self.enabled:
+            return True
+        return self.rank == 0
+
+    def get_world_size(self) -> int:
+        if not self.enabled:
+            return 1
+        return self.world_size

--- a/training/transformer/metrics.py
+++ b/training/transformer/metrics.py
@@ -3,9 +3,11 @@ from collections import defaultdict
 from typing import Any
 
 import torch
+import torch.distributed as dist
 from torch import Tensor
 from transformers import Trainer
 
+from training.transformer.distribute import Distribute
 from training.transformer.training_vocabulary import map_rhythm_symbol_with_position
 
 LOSS_COMPONENTS = [
@@ -25,8 +27,10 @@ class HomrTrainer(Trainer):
     and overall token-weighted (micro) accuracy.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, distribute: Distribute, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
+        self._distribute = distribute
 
         # Training loss accumulators
         self._loss_sum: dict[str, float] = defaultdict(float)
@@ -93,7 +97,12 @@ class HomrTrainer(Trainer):
         # Accumulate per-branch accuracy stats
         self._accumulate_accuracy(outputs, inputs)
 
-        loss = outputs["loss"].mean().detach().cpu()
+        if not self._distribute.enabled:
+            loss = outputs["loss"].mean().detach().cpu()
+        else:
+            # when using distributed training, loss on each device should be gathered,
+            # which can only run on gpu
+            loss = outputs["loss"].mean().detach()
         return loss, None, None
 
     def _accumulate_accuracy(
@@ -148,6 +157,20 @@ class HomrTrainer(Trainer):
                 self._acc_correct["pitch_nonposRhy"] += int((is_correct & is_nonpos).sum().item())
                 self._acc_total["pitch_nonposRhy"] += int(is_nonpos.sum().item())
 
+    def _all_reduce(self, d: dict[str, float]) -> None:
+        if not self._distribute.enabled or not d:
+            return
+
+        keys = sorted(d.keys())
+        tensor = torch.tensor(
+            [float(d[k]) for k in keys],
+            dtype=torch.float64,
+            device=torch.cuda.current_device(),
+        )
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM)
+        for i, k in enumerate(keys):
+            d[k] = tensor[i].item()
+
     def evaluation_loop(self, *args, metric_key_prefix="eval", **kwargs):  # type: ignore
         # Reset eval accumulators
         self._eval_loss_sum.clear()
@@ -160,6 +183,14 @@ class HomrTrainer(Trainer):
             metric_key_prefix=metric_key_prefix,
             **kwargs,
         )
+
+        for accumulator in [
+            self._eval_loss_sum,
+            self._eval_loss_count,
+            self._acc_correct,
+            self._acc_total,
+        ]:
+            self._all_reduce(accumulator)
 
         # Per-component eval losses
         for k in LOSS_COMPONENTS:

--- a/training/transformer/train.py
+++ b/training/transformer/train.py
@@ -24,6 +24,7 @@ from training.datasets.convert_lieder import convert_lieder, lieder_train_index
 from training.datasets.convert_primus import convert_primus_dataset, primus_train_index
 from training.run_id import get_run_id
 from training.transformer.data_loader import label_names, load_dataset
+from training.transformer.distribute import Distribute
 from training.transformer.metrics import HomrTrainer
 from training.transformer.mix_datasets import mix_training_sets
 
@@ -114,6 +115,8 @@ def _check_datasets_are_present(selected_datasets: list[str]) -> list[str]:
 def train_transformer(
     fp32: bool = False, resume: str = "", smoke_test: bool = False, fine_tune: bool = False
 ) -> None:
+    distribute = Distribute()
+
     number_of_epochs = 35
     if smoke_test:
         number_of_epochs = 10
@@ -125,23 +128,25 @@ def train_transformer(
     if resume:
         resume_from_checkpoint = os.path.join(git_root, checkpoint_folder, resume)
     elif os.path.exists(os.path.join(git_root, checkpoint_folder)):
-        shutil.rmtree(os.path.join(git_root, checkpoint_folder))
+        if distribute.is_rank0():
+            shutil.rmtree(os.path.join(git_root, checkpoint_folder))
+
+    dataset_index = [lieder_train_index, grandstaff_train_index, primus_train_index]
+    if distribute.is_rank0():
+        _check_datasets_are_present(dataset_index)
+    distribute.barrier()
 
     if smoke_test:
         number_of_files = -1
         train_index = load_and_mix_training_sets(
-            _check_datasets_are_present(
-                [lieder_train_index, grandstaff_train_index, primus_train_index]
-            ),
+            dataset_index,
             [1.0, 1.0, 1.0],
             number_of_files,
         )
     else:
         number_of_files = -1
         train_index = load_and_mix_training_sets(
-            _check_datasets_are_present(
-                [lieder_train_index, grandstaff_train_index, primus_train_index]
-            ),
+            dataset_index,
             [1.0, 1.0, 1.0],
             number_of_files,
         )
@@ -167,7 +172,7 @@ def train_transformer(
         save_strategy="epoch",
         learning_rate=1e-5 if fine_tune else 1e-4,
         optim="adamw_torch_fused",
-        gradient_accumulation_steps=4,
+        gradient_accumulation_steps=max(1, 4 // distribute.get_world_size()),
         per_device_train_batch_size=batch_size,
         per_device_eval_batch_size=batch_size // 2,
         num_train_epochs=number_of_epochs,
@@ -202,6 +207,7 @@ def train_transformer(
 
     if os.path.exists(model_destination):
         eprint("Model already exists", model_destination)
+        distribute.destroy()
         return
 
     try:
@@ -215,13 +221,17 @@ def train_transformer(
             train_dataset=datasets["train"],
             eval_dataset=datasets["validation"],
             callbacks=callbacks,
+            distribute=distribute,
         )
 
         trainer.train(resume_from_checkpoint=resume_from_checkpoint)
     except KeyboardInterrupt:
         eprint("Interrupted")
-    torch.save(model.state_dict(), model_destination)
-    eprint(f"Saved model to {model_destination}")
+    if distribute.is_rank0():
+        torch.save(model.state_dict(), model_destination)
+        eprint(f"Saved model to {model_destination}")
+    distribute.barrier()
+    distribute.destroy()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR enables training transformer on multi-gpu in parrallel. I'm not sure if other developpers need this, so it's totally ok if we don't merge it into main
## Code Change
`HomrTrainer` is subclass from `transformers.Trainer`, so it is already able to train distrubuted. We only need to ensure some work to run barely on rank0, because these works (like saving model, preparing dataset) are serial. 
## Test Run
run by 
```
CUDA_VISIBLE_DEVICES=4,5,6,7 poetry run torchrun 
  --standalone --nnodes=1 --nproc_per_node=4  training/transformer/train.py
```
and I see the 4 gpus running in parrallel
```
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    4   N/A  N/A         2729517      C   ...mr-jC662fEH-py3.12/bin/python      12650MiB |
|    5   N/A  N/A         2729518      C   ...mr-jC662fEH-py3.12/bin/python      12650MiB |
|    6   N/A  N/A         2729519      C   ...mr-jC662fEH-py3.12/bin/python      12650MiB |
|    7   N/A  N/A         2729520      C   ...mr-jC662fEH-py3.12/bin/python      12650MiB |
+-----------------------------------------------------------------------------------------+
```
and speedup is like 3.4x
- 1 gpu: 1.02it/s
- 4 gpu: 3.40it/s