### PR TITLE
fix accuracy for non-positional rhythm

### DIFF
--- a/training/architecture/transformer/decoder.py
+++ b/training/architecture/transformer/decoder.py
@@ -233,7 +233,9 @@ class ScoreDecoder(nn.Module):
     def __init__(self, transformer: ScoreTransformerWrapper, config: Config):
         super().__init__()
         self.pad_value = (config.pad_token,)
-        self.ignore_index = config.pad_token
+        # NOTE: nonote_token and pad_token currently share the same id (0).
+        # So we cannot use token id as ignore_index, otherwise "nonote" labels are ignored.
+        self.ignore_index = -100
         self.config = config
         self.net = transformer
         self.max_seq_len = config.max_seq_len
@@ -370,6 +372,7 @@ class ScoreDecoder(nn.Module):
 
         if mask.shape[1] == rhythms.shape[1]:
             mask = mask[:, :-1]
+        mask = mask.bool()
 
         # Scheduled Sampling: Two-pass approach
         if self.training and sampling_prob < 1.0:
@@ -436,6 +439,11 @@ class ScoreDecoder(nn.Module):
         loss_consist = beta * self.calConsistencyLoss(
             rhythmsp, pitchsp, liftsp, positionsp, articulationsp, mask
         )
+        rhythmso = self._mask_padding_tokens(rhythmso, mask)
+        pitchso = self._mask_padding_tokens(pitchso, mask)
+        liftso = self._mask_padding_tokens(liftso, mask)
+        articulationso = self._mask_padding_tokens(articulationso, mask)
+        positionso = self._mask_padding_tokens(positionso, mask)
         loss_rhythm = alpha * self.cross_entropy(rhythmsp, rhythmso, label_smoothing=0.1)
         loss_pitch = alpha * self.cross_entropy(pitchsp, pitchso)
         loss_lift = alpha * self.cross_entropy(liftsp, liftso)
@@ -512,6 +520,9 @@ class ScoreDecoder(nn.Module):
             ignore_index=self.ignore_index,
             label_smoothing=label_smoothing,
         )
+
+    def _mask_padding_tokens(self, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        return target.masked_fill(~mask, self.ignore_index)
 
 
 def init_cache(

--- a/training/transformer/metrics.py
+++ b/training/transformer/metrics.py
@@ -1,9 +1,12 @@
+import os
 from collections import defaultdict
 from typing import Any
 
 import torch
 from torch import Tensor
 from transformers import Trainer
+
+from training.transformer.training_vocabulary import map_rhythm_symbol_with_position
 
 LOSS_COMPONENTS = [
     "loss_rhythm",
@@ -34,6 +37,8 @@ class HomrTrainer(Trainer):
         self._eval_loss_count: dict[str, int] = defaultdict(int)
         self._acc_correct: dict[str, int] = defaultdict(int)
         self._acc_total: dict[str, int] = defaultdict(int)
+
+        self._rhythm_map = map_rhythm_symbol_with_position()
 
     def compute_loss(
         self,
@@ -100,6 +105,11 @@ class HomrTrainer(Trainer):
         # Pull binary mask from inputs and align with y_out (shift by 1)
         eval_mask = inputs["mask"][:, 1:]
 
+        rhythms_output = inputs["rhythms"][:, 1:]
+        _rhythm_map_on_device = self._rhythm_map.to(rhythms_output.device)
+        rhythms_output_clamped = rhythms_output.clamp(min=0, max=_rhythm_map_on_device.shape[0] - 1)
+        is_positional = _rhythm_map_on_device[rhythms_output_clamped]
+
         branches = [
             ("rhythm", rhythm, inputs["rhythms"]),
             ("pitch", pitch, inputs["pitchs"]),
@@ -127,6 +137,16 @@ class HomrTrainer(Trainer):
 
             self._acc_correct[name] += int(correct)
             self._acc_total[name] += int(total)
+
+            if name == "pitch" and os.environ.get("DEBUG_PITCH_RHYTHM_ACCURACY", "0") == "1":
+                current_is_pos = is_positional[:, :min_len]
+                is_correct = preds == labels
+                is_pos = mask & current_is_pos
+                is_nonpos = mask & (~current_is_pos)
+                self._acc_correct["pitch_posRhy"] += int((is_correct & is_pos).sum().item())
+                self._acc_total["pitch_posRhy"] += int(is_pos.sum().item())
+                self._acc_correct["pitch_nonposRhy"] += int((is_correct & is_nonpos).sum().item())
+                self._acc_total["pitch_nonposRhy"] += int(is_nonpos.sum().item())
 
     def evaluation_loop(self, *args, metric_key_prefix="eval", **kwargs):  # type: ignore
         # Reset eval accumulators

--- a/training/transformer/training_vocabulary.py
+++ b/training/transformer/training_vocabulary.py
@@ -4,7 +4,12 @@ from collections import defaultdict
 import torch
 
 from homr.transformer.configs import default_config
-from homr.transformer.vocabulary import EncodedSymbol, Vocabulary, sort_token_chords
+from homr.transformer.vocabulary import (
+    EncodedSymbol,
+    Vocabulary,
+    has_rhythm_symbol_a_position,
+    sort_token_chords,
+)
 
 vocab = Vocabulary()
 
@@ -201,6 +206,15 @@ class VocabularyStats:
 
     def __repr__(self) -> str:
         return str(self)
+
+
+def map_rhythm_symbol_with_position() -> torch.Tensor:
+    rhythm_vocab = vocab.rhythm
+    rhythm_map = torch.zeros(len(rhythm_vocab), dtype=torch.bool)
+    for rhythm, idx in rhythm_vocab.items():
+        if has_rhythm_symbol_a_position(rhythm):
+            rhythm_map[idx] = True
+    return rhythm_map
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe the Bug
@liebharc mentioned in #73 that sometimes `eval_pitch_accuracy ` stays at 0.6 to 0.7. I reproduce this issue, and see `eval_pitch_accuracy` stays at 0.67, while `eval_rhythm_accuracy` is correnct: 0.99. This doesn't happen very often, but I do reproduce it several times.

## Find Out What's Wrong
I run the smoke test, and manually check transcription result, where I find something interesting. Although eval_pitch_accuracy is 0.67, I see mostly (>90%) the pitches of notes are correct. So why is eval_pitch_accuracy so low?
Below is a function, which shows we can divide rhythm into two catagory: has position and non posiotion.
```
def has_rhythm_symbol_a_position(rhythm: str) -> bool:
    return rhythm.startswith(("note", "rest", "clef"))
```
- for has-position: yes, the pitch accuracy is high, I have checked via smoke test result
- for non-position: no, the pitch accuracy is low. And **this is indeed where the problem is**.

In this PR, I update `metrics.py` and add this record. From a test training, you can see `eval_pitch_nonposRhy_accuracy` is quite low.
```
eval_pitch_accuracy: 0.679374
eval_pitch_nonposRhy_accuracy: 0.089295
eval_pitch_posRhy_accuracy: 0.997130
eval_rhythm_accuracy: 0.996563
....(other metrics)
```
So why is `eval_pitch_nonposRhy_accuracy` so low?
Let's go to `vocabulary.py`. 
- In `def build_rhythm()`, token id 0 is padding. 
- In `def build_pitch()`, token id 0 is nonote. Nonote, e.g. , there isn't a pitch or note, e.g. , this is a non-position rhythm
So the suspect is, for label `nonote`, the training fails. So `eval_pitch_nonposRhy_accuracy` is low.

We can verify this suspect by looking at `class ScoreDecoder`. This line `self.ignore_index = config.pad_token` is wrong, because `pad_token` is token id 0, and `nonote` is also token id 0. If we let `pad_token` to be ignored, then `nonote` is also ignored. As a result, we see the pitch accuracy for non-position rhythm is low.

## How to Fix
That's easy. Don't let `ignore_index = config.pad_token`, but use `mask` to filter the invalid ones. 
After the fix, I have run the training(10 epochs) for 5 times, and don't see eval_pitch_accuracy to be 0.67 anymore.

## What's Next
- I will run training more times to ensure this won't happen again.
- All the trainings are run on #75 , not on branch main. But I assume this won't make a difference.
- To fix this bug, only code change in `decoder.py` is needed. Those in `metrics.py` are only used to diagnostic problems, and it's OK if we remove them.