### PR TITLE
FPN-style Fusion

### DIFF
--- a/Training.md
+++ b/Training.md
@@ -59,6 +59,27 @@ This validation provides a **more representative indication of overall system pe
 
 Implementation: `rate_validation_result.py`
 
+## Run 384 - discarded
+
+Commit: 0fee4303aeb8bb21a10fd0d7b457485a6d22fa0d
+Day: 5 Jun 2026
+Transformer Smoke Test: SER avg: 6%
+System Level: 6.4 diffs, SER: 5.2%
+
+## Run 385 - discarded
+
+Commit: 620d4591bcd716b722c894bc5546dc8f5d5e3a1c
+Day: 5 Jun 2026
+Transformer Smoke Test: SER avg: 7%
+System Level: 6.5 diffs, SER: 4.9%
+
+## Run 386 - discarded
+
+Commit: c1c0e3b126f2e2971c565197ce10bd752ad02687
+Day: 5 Jun 2026
+Transformer Smoke Test: SER avg: 6%
+System Level: 8.4 diffs, SER: 5.5%
+
 ## Run 381 - discarded
 
 Commit: 6ced21726443ed037608f8610ff4e7dac445649a

--- a/Training.md
+++ b/Training.md
@@ -66,6 +66,8 @@ Day: 5 Jun 2026
 Transformer Smoke Test: SER avg: 6%
 System Level: 6.4 diffs, SER: 5.2%
 
+Fusing 1&2
+
 ## Run 385 - discarded
 
 Commit: 620d4591bcd716b722c894bc5546dc8f5d5e3a1c
@@ -73,12 +75,16 @@ Day: 5 Jun 2026
 Transformer Smoke Test: SER avg: 7%
 System Level: 6.5 diffs, SER: 4.9%
 
+Fusing 1&2&3
+
 ## Run 386 - discarded
 
 Commit: c1c0e3b126f2e2971c565197ce10bd752ad02687
 Day: 5 Jun 2026
 Transformer Smoke Test: SER avg: 6%
 System Level: 8.4 diffs, SER: 5.5%
+
+Fusing 2&3
 
 ## Run 381 - discarded
 

--- a/Training.md
+++ b/Training.md
@@ -24,7 +24,7 @@ Download the datasets and convert them to the format required for training:
 
 - `training/datasets/convert_primus.py`
 - `training/datasets/convert_grandstaff.py`
-- `training/datasets/convert_lieder.py`  
+- `training/datasets/convert_lieder.py`
   - This will also download and run MuseScore as an AppImage. If this fails, check your setup to ensure that you can run `datasets/MuseScore`.
   - Not all files are supported. At the end you'll see something like `Processed 1460/1467 files, skipped 350 files`, which is as expected.
 
@@ -57,7 +57,14 @@ This validation provides a **more representative indication of overall system pe
 
 **Note:** The test dataset cannot be published due to copyright restrictions. In addition, the dataset is subject to change over time, which may affect the comparability of results across different runs.
 
-Implementation: `rate_validation_result.py`
+## Run 381
+
+Commit: 6ced21726443ed037608f8610ff4e7dac445649a
+Day: 1 Jun 2026
+Transformer Smoke Test: SER 6%
+System Level: 5.6 diffs, SER: 3.1%
+
+FPN Style fusion, https://github.com/liebharc/homr/pull/85
 
 ## Run 367
 

--- a/Training.md
+++ b/Training.md
@@ -57,14 +57,19 @@ This validation provides a **more representative indication of overall system pe
 
 **Note:** The test dataset cannot be published due to copyright restrictions. In addition, the dataset is subject to change over time, which may affect the comparability of results across different runs.
 
-## Run 381
+Implementation: `rate_validation_result.py`
+
+## Run 381 - discarded
 
 Commit: 6ced21726443ed037608f8610ff4e7dac445649a
 Day: 1 Jun 2026
 Transformer Smoke Test: SER 6%
 System Level: 5.6 diffs, SER: 3.1%
 
-FPN Style fusion, https://github.com/liebharc/homr/pull/85
+FPN Style fusion, https://github.com/liebharc/homr/pull/85 . The run is on good as e.g. #367 and #331, but the model is more complex and a manual review of the results indicate a less robust pitch detection.
+
+A possible way forward would be to not mix fused features, but instead concat stage 2 and stage 3. That however
+increases the encoder_dim and decoder_dim from 512 to 1152 (768 + 384) which makes training and inference much more expensive.
 
 ## Run 367
 

--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -87,7 +87,7 @@ class Config:
         self.vocab = Vocabulary()
         self.filepaths = FilePaths()
         self.channels = 1
-        self.patch_size = 8
+        self.patch_size = 16
         self.max_height = 256
         self.max_width = 1280
         self.max_seq_len = 608

--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -87,7 +87,7 @@ class Config:
         self.vocab = Vocabulary()
         self.filepaths = FilePaths()
         self.channels = 1
-        self.patch_size = 16
+        self.patch_size = 8
         self.max_height = 256
         self.max_width = 1280
         self.max_seq_len = 608

--- a/training/architecture/transformer/encoder.py
+++ b/training/architecture/transformer/encoder.py
@@ -2,17 +2,33 @@ from typing import Any
 
 import timm
 import torch
-from timm.layers import trunc_normal_  # type: ignore
 from torch import nn
 
 from homr.transformer.configs import Config
 
 
+def _get_sinusoid_encoding(n_position: int, d_hid: int) -> torch.Tensor:
+    position = torch.arange(n_position, dtype=torch.float).unsqueeze(1)
+    div_term = torch.exp(
+        torch.arange(0, d_hid, 2, dtype=torch.float) * -(torch.log(torch.tensor(10000.0)) / d_hid)
+    )
+    sinusoid_table = torch.zeros(n_position, d_hid)
+    sinusoid_table[:, 0::2] = torch.sin(position * div_term[: (d_hid + 1) // 2])
+    sinusoid_table[:, 1::2] = torch.cos(position * div_term[: d_hid // 2])
+    return sinusoid_table.unsqueeze(0)
+
+
 class ConvNeXtEncoder(nn.Module):
-    def __init__(self, config: Config):
+    """
+    ConvNeXt encoder with exact-correspondence multi-scale fusion.
+    Each stage3 patch is tiled onto its 4 stage2 children via repeat_interleave,
+    preserving the strict 1:4 spatial relationship the backbone computes.
+    No interpolation across patch boundaries — pitch resolution is fully preserved.
+    """
+
+    def __init__(self, config: Config) -> None:
         super().__init__()
 
-        # Use configurable pretrained flag
         self.model = timm.create_model(
             "convnext_tiny",
             pretrained=True,
@@ -22,73 +38,75 @@ class ConvNeXtEncoder(nn.Module):
             drop_path_rate=0.1,
         )
 
-        self.encoder_dim = config.encoder_dim
+        stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore
+        stage3_chs: int = int(self.model.feature_info[3]["num_chs"])  # type: ignore
 
-        # Extract features up to stage 2 (stride 16)
-        self.feature_info = self.model.feature_info[2]  # type: ignore
-        in_features = int(self.feature_info["num_chs"])  # type: ignore
-        self.proj = nn.Linear(in_features, config.encoder_dim)
+        # Reduce stage3 channels to match stage2 before tiling
+        self.stage3_lateral = nn.Conv2d(stage3_chs, stage2_chs, kernel_size=1)
 
-        # Instead of learning pos_embed for each of 1280 positions,
-        # we learn separate embeddings for 80 horizontal + 16 vertical positions
-        # Memory: (1280 * D) vs (80 * D + 16 * D) = ~14x less parameters
-        num_patches_h = config.max_height // 16  # 256 / 16 = 16 (vertical/pitch)
-        num_patches_w = config.max_width // 16  # 1280 / 16 = 80 (horizontal/time)
+        # Gate starts near zero: stage3 must earn its contribution
+        self.fpn_gate = nn.Parameter(torch.full((1,), -4.0))
 
-        # Split encoder_dim between height and width embeddings
-        # Give slightly more capacity to vertical (pitch) dimension
+        # Depthwise-separable conv to mix fused features spatially
+        self.fuse_conv = nn.Sequential(
+            nn.Conv2d(stage2_chs, stage2_chs, kernel_size=3, padding=1, groups=stage2_chs),
+            nn.Conv2d(stage2_chs, stage2_chs, kernel_size=1),
+            nn.GroupNorm(32, stage2_chs),
+            nn.GELU(),
+        )
+
+        hidden_dim = max(config.encoder_dim * 2, stage2_chs * 2)
+        self.proj = nn.Sequential(
+            nn.Linear(stage2_chs, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, config.encoder_dim),
+        )
+
+        num_patches_h = config.max_height // 16  # 256 // 16 = 16
+        num_patches_w = config.max_width // 16  # 1280 // 16 = 80
+
         self.h_dim = config.encoder_h_dim
         self.w_dim = config.encoder_dim - self.h_dim
 
-        self.pos_embed_h = nn.Parameter(torch.zeros(1, num_patches_h, self.h_dim))
-        self.pos_embed_w = nn.Parameter(torch.zeros(1, num_patches_w, self.w_dim))
-
-        trunc_normal_(self.pos_embed_h, std=0.02)
-        trunc_normal_(self.pos_embed_w, std=0.02)
+        self.pos_embed_h = nn.Parameter(
+            _get_sinusoid_encoding(num_patches_h, self.h_dim), requires_grad=True
+        )
+        self.pos_embed_w = nn.Parameter(
+            _get_sinusoid_encoding(num_patches_w, self.w_dim), requires_grad=True
+        )
 
     def freeze_backbone(self) -> None:
-        """Freeze only the ConvNeXt backbone parameters."""
-        for param in self.model.parameters():
-            param.requires_grad = False
+        for p in self.model.parameters():
+            p.requires_grad = False
 
     def unfreeze_backbone(self) -> None:
-        """Unfreeze the ConvNeXt backbone parameters."""
-        for param in self.model.parameters():
-            param.requires_grad = True
+        for p in self.model.parameters():
+            p.requires_grad = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        _, requested_stages = self.model.forward_intermediates(x, indices=[2])  # type: ignore
-        features = requested_stages[0]  # Get stage 2 (stride 16)
+        _, stages = self.model.forward_intermediates(x, indices=[2, 3])  # type: ignore
+        feat2 = stages[0]
+        feat3 = stages[1]
 
-        # features shape: (B, C, H, W) = (B, 384, 16, 80)
-        b, c, h, w = features.shape
-        # Rearrange to (B, H, W, C)
+        feat3 = self.stage3_lateral(feat3)
+
+        # Tile each stage3 patch onto its exact 4 stage2 children.
+        # No learned interpolation — zero cross-patch contamination.
+        feat3_tiled = feat3.repeat_interleave(2, dim=2).repeat_interleave(2, dim=3)
+        feat3_tiled = feat3_tiled[:, :, : feat2.shape[2], : feat2.shape[3]]
+
+        features = self.fuse_conv(feat2 + torch.sigmoid(self.fpn_gate) * feat3_tiled)
+        b, _c, h, w = features.shape
+
         features = features.permute(0, 2, 3, 1)
+        features = self.proj(features)
 
-        # Project to encoder_dim
-        features = self.proj(features)  # (B, H, W, D)
-
-        # Add factorized positional embeddings
-        # self.pos_embed_h is (1, 80, h_dim) -> (1, 80, 1, h_dim)
-        # self.pos_embed_w is (1, 16, w_dim) -> (1, 1, 16, w_dim)
-        # Why this works:
-        # Each position gets a full embedding by combining a vertical and horizontal vector.
-        # Vertical embeddings are learned once and reused across all columns,
-        # so the model efficiently learns how pitch relates to row position.
-        # Horizontal embeddings handle time separately.
-        # This factorization focuses capacity where it matters and reduces
-        # parameters while preserving positional information.
-        pos_h = self.pos_embed_h.unsqueeze(2).expand(-1, -1, w, -1)
-        pos_w = self.pos_embed_w.unsqueeze(1).expand(-1, h, -1, -1)
-
-        # Concatenate dimension: (1, 80, 16, D)
+        pos_h = self.pos_embed_h[:, :h, :].unsqueeze(2).expand(-1, -1, w, -1)
+        pos_w = self.pos_embed_w[:, :w, :].unsqueeze(1).expand(-1, h, -1, -1)
         pos_embed = torch.cat([pos_h, pos_w], dim=-1)
+
         features = features + pos_embed
-
-        # Flatten to sequence: (B, H, W, D) -> (B, H*W, D)
-        features = features.reshape(b, h * w, -1)
-
-        return features
+        return features.reshape(b, h * w, -1)
 
 
 def get_encoder(config: Config) -> Any:

--- a/training/architecture/transformer/encoder.py
+++ b/training/architecture/transformer/encoder.py
@@ -19,24 +19,32 @@ def _get_sinusoid_encoding(n_position: int, d_hid: int) -> torch.Tensor:
     return sinusoid_table.unsqueeze(0)
 
 
+def _make_output_conv(channels: int) -> nn.Sequential:
+    """Standard FPN smoothing conv: 3×3 + GroupNorm + GELU."""
+    return nn.Sequential(
+        nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False),
+        nn.GroupNorm(32, channels),
+        nn.GELU(),
+    )
+
+
 class ConvNeXtEncoder(nn.Module):
     """
-    ConvNeXt encoder with standard FPN-style top-down fusion of stage1 + stage2.
+    ConvNeXt encoder with 3-stage FPN fusion (indices [1, 2, 3]).
 
     ConvNeXt-Tiny channel/stride map (timm feature_info indices):
       [0]  96ch  stride  4
       [1] 192ch  stride  8  ← feat1 (fine spatial detail)
-      [2] 384ch  stride 16  ← feat2 (semantic context)
-      [3] 768ch  stride 32
+      [2] 384ch  stride 16  ← feat2 (mid-range structure)
+      [3] 768ch  stride 32  ← feat3 (global context: clefs, key sigs, bar structure)
 
-    Fusion (indices=[1, 2]) produces stride-8 output → 32×160 tokens for 256×1280 input.
+    Two cascaded FPN merges, top-down:
+      feat3 (stride 32) → lateral → upsample → add into feat2
+      feat2 (stride 16) → lateral → upsample → add into feat1  (carries feat3 signal)
+      feat1 (stride  8) → lateral → final output at stride 8
 
-    Standard FPN steps:
-      1. lateral 1×1 conv  — project each scale to fpn_channels (192, the finer width)
-      2. F.interpolate(size=, nearest)  — upsample feat2 to feat1 spatial size
-      3. element-wise addition  — inject top-down semantic context
-      4. 3×3 conv + GroupNorm + GELU  — smooth aliasing from upsampling
-      5. 1×1 conv  — project fpn_channels → encoder_dim
+    Output: (B, 32×160, encoder_dim) for 256×1280 input.
+    Transformer token count: 5120 — same as [1,2] fusion, no extra cost.
     """
 
     def __init__(self, config: Config) -> None:
@@ -51,26 +59,25 @@ class ConvNeXtEncoder(nn.Module):
             drop_path_rate=0.1,
         )
 
-        # convnext_tiny: feat1 = 192ch stride 8, feat2 = 384ch stride 16
+        # convnext_tiny confirmed channel sizes:
         stage1_chs: int = int(self.model.feature_info[1]["num_chs"])  # type: ignore  → 192
         stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore  → 384
-        fpn_channels: int = stage1_chs  # 192 — use finer scale width as common FPN width
+        stage3_chs: int = int(self.model.feature_info[3]["num_chs"])  # type: ignore  → 768
+        fpn_channels: int = stage1_chs  # 192 — common FPN width throughout all levels
 
-        # Step 1: lateral 1×1 convs — align both scales to fpn_channels
-        # stage1 is already 192ch but we still apply 1×1 for consistent learned projection
+        # Lateral 1×1 convs — project each scale to fpn_channels
+        # stage1 already 192ch but explicit projection keeps all levels symmetric
         self.lateral_stage1 = nn.Conv2d(stage1_chs, fpn_channels, kernel_size=1, bias=False)
         self.lateral_stage2 = nn.Conv2d(stage2_chs, fpn_channels, kernel_size=1, bias=False)
+        self.lateral_stage3 = nn.Conv2d(stage3_chs, fpn_channels, kernel_size=1, bias=False)
 
-        # Step 4: 3×3 smoothing conv — reduces aliasing artifacts after addition
-        self.output_conv = nn.Sequential(
-            nn.Conv2d(fpn_channels, fpn_channels, kernel_size=3, padding=1, bias=False),
-            nn.GroupNorm(32, fpn_channels),
-            nn.GELU(),
-        )
+        # Smoothing convs — one per merge point (after each addition)
+        # output_conv_2: applied after merging feat3 into feat2 (stride 16)
+        # output_conv_1: applied after merging fused-feat2 into feat1 (stride 8, final)
+        self.output_conv_2 = _make_output_conv(fpn_channels)
+        self.output_conv_1 = _make_output_conv(fpn_channels)
 
-        # Step 5: 1×1 projection — expand fpn_channels (192) → encoder_dim (512 or 768)
-        # Equivalent to a per-token linear layer; no hidden layer needed here since
-        # the transformer encoder that follows handles all channel mixing.
+        # Final 1×1 projection: fpn_channels (192) → encoder_dim (512 or 768)
         self.proj = nn.Conv2d(fpn_channels, config.encoder_dim, kernel_size=1, bias=False)
 
         # Stride-8 output: 256//8=32 height patches, 1280//8=160 width patches
@@ -96,29 +103,32 @@ class ConvNeXtEncoder(nn.Module):
             p.requires_grad = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        _, stages = self.model.forward_intermediates(x, indices=[1, 2])  # type: ignore
-        feat1 = stages[0]  # (B, 192, H/8,  W/8)  — stride-8, fine spatial detail
-        feat2 = stages[1]  # (B, 384, H/16, W/16) — stride-16, semantic context
+        _, stages = self.model.forward_intermediates(x, indices=[1, 2, 3])  # type: ignore
+        feat1 = stages[0]  # (B, 192, H/8,  W/8)
+        feat2 = stages[1]  # (B, 384, H/16, W/16)
+        feat3 = stages[2]  # (B, 768, H/32, W/32)
 
-        # Step 1: lateral projections → common channel width (192)
+        # Step 1: lateral projections — all scales → 192ch
         lat1 = self.lateral_stage1(feat1)
         lat2 = self.lateral_stage2(feat2)
+        lat3 = self.lateral_stage3(feat3)
 
-        # Step 2: upsample stride-16 → stride-8 using exact target size (robust to odd dims)
-        top_down = F.interpolate(lat2, size=lat1.shape[-2:], mode="nearest")
+        # Step 2: top-down merge — feat3 into feat2 (stride 32 → 16)
+        # lat3 carries global context (clefs, key signatures, bar-level structure)
+        top_down_2 = F.interpolate(lat3, size=lat2.shape[-2:], mode="nearest")
+        fused2 = self.output_conv_2(lat2 + top_down_2)  # (B, 192, H/16, W/16)
 
-        # Step 3: element-wise addition — merge semantic context into fine spatial features
-        fused = lat1 + top_down
+        # Step 3: top-down merge — fused feat2 into feat1 (stride 16 → 8)
+        # fused2 already carries feat3 signal, so feat3 context reaches stride-8 tokens
+        top_down_1 = F.interpolate(fused2, size=lat1.shape[-2:], mode="nearest")
+        fused1 = self.output_conv_1(lat1 + top_down_1)  # (B, 192, H/8, W/8)
 
-        # Step 4: smooth aliasing from upsampling + addition
-        fused = self.output_conv(fused)  # (B, 192, H/8, W/8)
-
-        # Step 5: project to encoder_dim via 1×1 conv (= per-token linear, no hidden layer)
-        fused = self.proj(fused)  # (B, encoder_dim, H/8, W/8)
+        # Step 4: project to encoder_dim
+        fused = self.proj(fused1)  # (B, encoder_dim, H/8, W/8)
 
         b, _c, h, w = fused.shape
 
-        # Positional embeddings — factorized H×W → separate h_dim + w_dim embeddings
+        # Factorized positional embeddings — separate h_dim + w_dim vectors per axis
         pos_h = self.pos_embed_h[:, :h, :].unsqueeze(2).expand(-1, -1, w, -1)
         pos_w = self.pos_embed_w[:, :w, :].unsqueeze(1).expand(-1, h, -1, -1)
         pos_embed = torch.cat([pos_h, pos_w], dim=-1)

--- a/training/architecture/transformer/encoder.py
+++ b/training/architecture/transformer/encoder.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import timm
 import torch
-import torch.nn.functional as F
 from torch import nn
 
 from homr.transformer.configs import Config
@@ -20,29 +19,10 @@ def _get_sinusoid_encoding(n_position: int, d_hid: int) -> torch.Tensor:
 
 
 class ConvNeXtEncoder(nn.Module):
-    """
-    ConvNeXt encoder with standard FPN-style top-down fusion of stage2 + stage3.
-
-    ConvNeXt-Tiny channel/stride map (timm feature_info indices):
-      [0]  96ch  stride  4
-      [1] 192ch  stride  8
-      [2] 384ch  stride 16  ← feat2 (fine scale, output resolution)
-      [3] 768ch  stride 32  ← feat3 (global context: clefs, key sigs, bar structure)
-
-    Single FPN merge (indices=[2, 3]), output at stride 16.
-    Token count: 16×80 = 1280 for 256×1280 input — same as the original encoder.
-
-    Standard FPN steps:
-      1. lateral 1×1 conv  — project each scale to fpn_channels (384, the finer width)
-      2. F.interpolate(size=, nearest)  — upsample feat3 to feat2 spatial size
-      3. element-wise addition  — inject global context into spatial features
-      4. 3×3 conv + GroupNorm + GELU  — smooth aliasing from upsampling
-      5. 1×1 conv  — project fpn_channels (384) → encoder_dim (512 or 768)
-    """
-
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config):
         super().__init__()
 
+        # Use configurable pretrained flag
         self.model = timm.create_model(
             "convnext_tiny",
             pretrained=True,
@@ -52,29 +32,21 @@ class ConvNeXtEncoder(nn.Module):
             drop_path_rate=0.1,
         )
 
-        # convnext_tiny confirmed channel sizes:
-        stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore  → 384
-        stage3_chs: int = int(self.model.feature_info[3]["num_chs"])  # type: ignore  → 768
-        fpn_channels: int = stage2_chs  # 384 — use finer scale width as common FPN width
+        self.encoder_dim = config.encoder_dim
 
-        # Step 1: lateral 1×1 convs — project both scales to fpn_channels
-        self.lateral_stage2 = nn.Conv2d(stage2_chs, fpn_channels, kernel_size=1, bias=False)
-        self.lateral_stage3 = nn.Conv2d(stage3_chs, fpn_channels, kernel_size=1, bias=False)
+        # Extract features up to stage 2 (stride 16)
+        self.feature_info = self.model.feature_info[2]  # type: ignore
+        in_features = int(self.feature_info["num_chs"])  # type: ignore
+        self.proj = nn.Linear(in_features, config.encoder_dim)
 
-        # Step 4: 3×3 smoothing conv — reduces aliasing after addition
-        self.output_conv = nn.Sequential(
-            nn.Conv2d(fpn_channels, fpn_channels, kernel_size=3, padding=1, bias=False),
-            nn.GroupNorm(32, fpn_channels),
-            nn.GELU(),
-        )
+        # Instead of learning pos_embed for each of 1280 positions,
+        # we learn separate embeddings for 80 horizontal + 16 vertical positions
+        # Memory: (1280 * D) vs (80 * D + 16 * D) = ~14x less parameters
+        num_patches_h = config.max_height // 16  # 256 / 16 = 16 (vertical/pitch)
+        num_patches_w = config.max_width // 16  # 1280 / 16 = 80 (horizontal/time)
 
-        # Step 5: 1×1 projection — fpn_channels (384) → encoder_dim (512 or 768)
-        self.proj = nn.Conv2d(fpn_channels, config.encoder_dim, kernel_size=1, bias=False)
-
-        # Stride-16 output: 256//16=16 height patches, 1280//16=80 width patches
-        num_patches_h = config.max_height // 16  # 16 (vertical / pitch)
-        num_patches_w = config.max_width // 16   # 80 (horizontal / time)
-
+        # Split encoder_dim between height and width embeddings
+        # Give slightly more capacity to vertical (pitch) dimension
         self.h_dim = config.encoder_h_dim
         self.w_dim = config.encoder_dim - self.h_dim
 
@@ -86,44 +58,48 @@ class ConvNeXtEncoder(nn.Module):
         )
 
     def freeze_backbone(self) -> None:
-        for p in self.model.parameters():
-            p.requires_grad = False
+        """Freeze only the ConvNeXt backbone parameters."""
+        for param in self.model.parameters():
+            param.requires_grad = False
 
     def unfreeze_backbone(self) -> None:
-        for p in self.model.parameters():
-            p.requires_grad = True
+        """Unfreeze the ConvNeXt backbone parameters."""
+        for param in self.model.parameters():
+            param.requires_grad = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        _, stages = self.model.forward_intermediates(x, indices=[2, 3])  # type: ignore
-        feat2 = stages[0]  # (B, 384, H/16, W/16) — stride-16, fine spatial detail
-        feat3 = stages[1]  # (B, 768, H/32, W/32) — stride-32, global context
+        _, requested_stages = self.model.forward_intermediates(x, indices=[2])  # type: ignore
+        features = requested_stages[0]  # Get stage 2 (stride 16)
 
-        # Step 1: lateral projections → 384ch
-        lat2 = self.lateral_stage2(feat2)
-        lat3 = self.lateral_stage3(feat3)
+        # features shape: (B, C, H, W) = (B, 384, 16, 80)
+        b, c, h, w = features.shape
+        # Rearrange to (B, H, W, C)
+        features = features.permute(0, 2, 3, 1)
 
-        # Step 2: upsample stride-32 → stride-16 using exact target size
-        top_down = F.interpolate(lat3, size=lat2.shape[-2:], mode="nearest")
+        # Project to encoder_dim
+        features = self.proj(features)  # (B, H, W, D)
 
-        # Step 3: element-wise addition — merge global context into spatial features
-        fused = lat2 + top_down
+        # Add factorized positional embeddings
+        # self.pos_embed_h is (1, 80, h_dim) -> (1, 80, 1, h_dim)
+        # self.pos_embed_w is (1, 16, w_dim) -> (1, 1, 16, w_dim)
+        # Why this works:
+        # Each position gets a full embedding by combining a vertical and horizontal vector.
+        # Vertical embeddings are learned once and reused across all columns,
+        # so the model efficiently learns how pitch relates to row position.
+        # Horizontal embeddings handle time separately.
+        # This factorization focuses capacity where it matters and reduces
+        # parameters while preserving positional information.
+        pos_h = self.pos_embed_h.unsqueeze(2).expand(-1, -1, w, -1)
+        pos_w = self.pos_embed_w.unsqueeze(1).expand(-1, h, -1, -1)
 
-        # Step 4: smooth aliasing from upsampling + addition
-        fused = self.output_conv(fused)  # (B, 384, H/16, W/16)
-
-        # Step 5: project to encoder_dim
-        fused = self.proj(fused)  # (B, encoder_dim, H/16, W/16)
-
-        b, _c, h, w = fused.shape
-
-        # Factorized positional embeddings
-        pos_h = self.pos_embed_h[:, :h, :].unsqueeze(2).expand(-1, -1, w, -1)
-        pos_w = self.pos_embed_w[:, :w, :].unsqueeze(1).expand(-1, h, -1, -1)
+        # Concatenate dimension: (1, 80, 16, D)
         pos_embed = torch.cat([pos_h, pos_w], dim=-1)
+        features = features + pos_embed
 
-        # (B, C, H, W) → (B, H, W, C) → add pos → (B, H*W, encoder_dim)
-        fused = fused.permute(0, 2, 3, 1) + pos_embed
-        return fused.reshape(b, h * w, -1)
+        # Flatten to sequence: (B, H, W, D) -> (B, H*W, D)
+        features = features.reshape(b, h * w, -1)
+
+        return features
 
 
 def get_encoder(config: Config) -> Any:

--- a/training/architecture/transformer/encoder.py
+++ b/training/architecture/transformer/encoder.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import timm
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from homr.transformer.configs import Config
@@ -20,10 +21,22 @@ def _get_sinusoid_encoding(n_position: int, d_hid: int) -> torch.Tensor:
 
 class ConvNeXtEncoder(nn.Module):
     """
-    ConvNeXt encoder with exact-correspondence multi-scale fusion.
-    Each stage3 patch is tiled onto its 4 stage2 children via repeat_interleave,
-    preserving the strict 1:4 spatial relationship the backbone computes.
-    No interpolation across patch boundaries — pitch resolution is fully preserved.
+    ConvNeXt encoder with standard FPN-style top-down fusion of stage1 + stage2.
+
+    ConvNeXt-Tiny channel/stride map (timm feature_info indices):
+      [0]  96ch  stride  4
+      [1] 192ch  stride  8  ← feat1 (fine spatial detail)
+      [2] 384ch  stride 16  ← feat2 (semantic context)
+      [3] 768ch  stride 32
+
+    Fusion (indices=[1, 2]) produces stride-8 output → 32×160 tokens for 256×1280 input.
+
+    Standard FPN steps:
+      1. lateral 1×1 conv  — project each scale to fpn_channels (192, the finer width)
+      2. F.interpolate(size=, nearest)  — upsample feat2 to feat1 spatial size
+      3. element-wise addition  — inject top-down semantic context
+      4. 3×3 conv + GroupNorm + GELU  — smooth aliasing from upsampling
+      5. 1×1 conv  — project fpn_channels → encoder_dim
     """
 
     def __init__(self, config: Config) -> None:
@@ -38,32 +51,31 @@ class ConvNeXtEncoder(nn.Module):
             drop_path_rate=0.1,
         )
 
-        stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore
-        stage3_chs: int = int(self.model.feature_info[3]["num_chs"])  # type: ignore
+        # convnext_tiny: feat1 = 192ch stride 8, feat2 = 384ch stride 16
+        stage1_chs: int = int(self.model.feature_info[1]["num_chs"])  # type: ignore  → 192
+        stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore  → 384
+        fpn_channels: int = stage1_chs  # 192 — use finer scale width as common FPN width
 
-        # Reduce stage3 channels to match stage2 before tiling
-        self.stage3_lateral = nn.Conv2d(stage3_chs, stage2_chs, kernel_size=1)
+        # Step 1: lateral 1×1 convs — align both scales to fpn_channels
+        # stage1 is already 192ch but we still apply 1×1 for consistent learned projection
+        self.lateral_stage1 = nn.Conv2d(stage1_chs, fpn_channels, kernel_size=1, bias=False)
+        self.lateral_stage2 = nn.Conv2d(stage2_chs, fpn_channels, kernel_size=1, bias=False)
 
-        # Gate starts near zero: stage3 must earn its contribution
-        self.fpn_gate = nn.Parameter(torch.full((1,), -4.0))
-
-        # Depthwise-separable conv to mix fused features spatially
-        self.fuse_conv = nn.Sequential(
-            nn.Conv2d(stage2_chs, stage2_chs, kernel_size=3, padding=1, groups=stage2_chs),
-            nn.Conv2d(stage2_chs, stage2_chs, kernel_size=1),
-            nn.GroupNorm(32, stage2_chs),
+        # Step 4: 3×3 smoothing conv — reduces aliasing artifacts after addition
+        self.output_conv = nn.Sequential(
+            nn.Conv2d(fpn_channels, fpn_channels, kernel_size=3, padding=1, bias=False),
+            nn.GroupNorm(32, fpn_channels),
             nn.GELU(),
         )
 
-        hidden_dim = max(config.encoder_dim * 2, stage2_chs * 2)
-        self.proj = nn.Sequential(
-            nn.Linear(stage2_chs, hidden_dim),
-            nn.GELU(),
-            nn.Linear(hidden_dim, config.encoder_dim),
-        )
+        # Step 5: 1×1 projection — expand fpn_channels (192) → encoder_dim (512 or 768)
+        # Equivalent to a per-token linear layer; no hidden layer needed here since
+        # the transformer encoder that follows handles all channel mixing.
+        self.proj = nn.Conv2d(fpn_channels, config.encoder_dim, kernel_size=1, bias=False)
 
-        num_patches_h = config.max_height // 16  # 256 // 16 = 16
-        num_patches_w = config.max_width // 16  # 1280 // 16 = 80
+        # Stride-8 output: 256//8=32 height patches, 1280//8=160 width patches
+        num_patches_h = config.max_height // 8   # 32  (vertical / pitch)
+        num_patches_w = config.max_width // 8    # 160 (horizontal / time)
 
         self.h_dim = config.encoder_h_dim
         self.w_dim = config.encoder_dim - self.h_dim
@@ -84,29 +96,36 @@ class ConvNeXtEncoder(nn.Module):
             p.requires_grad = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        _, stages = self.model.forward_intermediates(x, indices=[2, 3])  # type: ignore
-        feat2 = stages[0]
-        feat3 = stages[1]
+        _, stages = self.model.forward_intermediates(x, indices=[1, 2])  # type: ignore
+        feat1 = stages[0]  # (B, 192, H/8,  W/8)  — stride-8, fine spatial detail
+        feat2 = stages[1]  # (B, 384, H/16, W/16) — stride-16, semantic context
 
-        feat3 = self.stage3_lateral(feat3)
+        # Step 1: lateral projections → common channel width (192)
+        lat1 = self.lateral_stage1(feat1)
+        lat2 = self.lateral_stage2(feat2)
 
-        # Tile each stage3 patch onto its exact 4 stage2 children.
-        # No learned interpolation — zero cross-patch contamination.
-        feat3_tiled = feat3.repeat_interleave(2, dim=2).repeat_interleave(2, dim=3)
-        feat3_tiled = feat3_tiled[:, :, : feat2.shape[2], : feat2.shape[3]]
+        # Step 2: upsample stride-16 → stride-8 using exact target size (robust to odd dims)
+        top_down = F.interpolate(lat2, size=lat1.shape[-2:], mode="nearest")
 
-        features = self.fuse_conv(feat2 + torch.sigmoid(self.fpn_gate) * feat3_tiled)
-        b, _c, h, w = features.shape
+        # Step 3: element-wise addition — merge semantic context into fine spatial features
+        fused = lat1 + top_down
 
-        features = features.permute(0, 2, 3, 1)
-        features = self.proj(features)
+        # Step 4: smooth aliasing from upsampling + addition
+        fused = self.output_conv(fused)  # (B, 192, H/8, W/8)
 
+        # Step 5: project to encoder_dim via 1×1 conv (= per-token linear, no hidden layer)
+        fused = self.proj(fused)  # (B, encoder_dim, H/8, W/8)
+
+        b, _c, h, w = fused.shape
+
+        # Positional embeddings — factorized H×W → separate h_dim + w_dim embeddings
         pos_h = self.pos_embed_h[:, :h, :].unsqueeze(2).expand(-1, -1, w, -1)
         pos_w = self.pos_embed_w[:, :w, :].unsqueeze(1).expand(-1, h, -1, -1)
         pos_embed = torch.cat([pos_h, pos_w], dim=-1)
 
-        features = features + pos_embed
-        return features.reshape(b, h * w, -1)
+        # (B, C, H, W) → (B, H, W, C) → add pos → (B, H*W, encoder_dim)
+        fused = fused.permute(0, 2, 3, 1) + pos_embed
+        return fused.reshape(b, h * w, -1)
 
 
 def get_encoder(config: Config) -> Any:

--- a/training/architecture/transformer/encoder.py
+++ b/training/architecture/transformer/encoder.py
@@ -19,32 +19,25 @@ def _get_sinusoid_encoding(n_position: int, d_hid: int) -> torch.Tensor:
     return sinusoid_table.unsqueeze(0)
 
 
-def _make_output_conv(channels: int) -> nn.Sequential:
-    """Standard FPN smoothing conv: 3×3 + GroupNorm + GELU."""
-    return nn.Sequential(
-        nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False),
-        nn.GroupNorm(32, channels),
-        nn.GELU(),
-    )
-
-
 class ConvNeXtEncoder(nn.Module):
     """
-    ConvNeXt encoder with 3-stage FPN fusion (indices [1, 2, 3]).
+    ConvNeXt encoder with standard FPN-style top-down fusion of stage2 + stage3.
 
     ConvNeXt-Tiny channel/stride map (timm feature_info indices):
       [0]  96ch  stride  4
-      [1] 192ch  stride  8  ← feat1 (fine spatial detail)
-      [2] 384ch  stride 16  ← feat2 (mid-range structure)
+      [1] 192ch  stride  8
+      [2] 384ch  stride 16  ← feat2 (fine scale, output resolution)
       [3] 768ch  stride 32  ← feat3 (global context: clefs, key sigs, bar structure)
 
-    Two cascaded FPN merges, top-down:
-      feat3 (stride 32) → lateral → upsample → add into feat2
-      feat2 (stride 16) → lateral → upsample → add into feat1  (carries feat3 signal)
-      feat1 (stride  8) → lateral → final output at stride 8
+    Single FPN merge (indices=[2, 3]), output at stride 16.
+    Token count: 16×80 = 1280 for 256×1280 input — same as the original encoder.
 
-    Output: (B, 32×160, encoder_dim) for 256×1280 input.
-    Transformer token count: 5120 — same as [1,2] fusion, no extra cost.
+    Standard FPN steps:
+      1. lateral 1×1 conv  — project each scale to fpn_channels (384, the finer width)
+      2. F.interpolate(size=, nearest)  — upsample feat3 to feat2 spatial size
+      3. element-wise addition  — inject global context into spatial features
+      4. 3×3 conv + GroupNorm + GELU  — smooth aliasing from upsampling
+      5. 1×1 conv  — project fpn_channels (384) → encoder_dim (512 or 768)
     """
 
     def __init__(self, config: Config) -> None:
@@ -60,29 +53,27 @@ class ConvNeXtEncoder(nn.Module):
         )
 
         # convnext_tiny confirmed channel sizes:
-        stage1_chs: int = int(self.model.feature_info[1]["num_chs"])  # type: ignore  → 192
         stage2_chs: int = int(self.model.feature_info[2]["num_chs"])  # type: ignore  → 384
         stage3_chs: int = int(self.model.feature_info[3]["num_chs"])  # type: ignore  → 768
-        fpn_channels: int = stage1_chs  # 192 — common FPN width throughout all levels
+        fpn_channels: int = stage2_chs  # 384 — use finer scale width as common FPN width
 
-        # Lateral 1×1 convs — project each scale to fpn_channels
-        # stage1 already 192ch but explicit projection keeps all levels symmetric
-        self.lateral_stage1 = nn.Conv2d(stage1_chs, fpn_channels, kernel_size=1, bias=False)
+        # Step 1: lateral 1×1 convs — project both scales to fpn_channels
         self.lateral_stage2 = nn.Conv2d(stage2_chs, fpn_channels, kernel_size=1, bias=False)
         self.lateral_stage3 = nn.Conv2d(stage3_chs, fpn_channels, kernel_size=1, bias=False)
 
-        # Smoothing convs — one per merge point (after each addition)
-        # output_conv_2: applied after merging feat3 into feat2 (stride 16)
-        # output_conv_1: applied after merging fused-feat2 into feat1 (stride 8, final)
-        self.output_conv_2 = _make_output_conv(fpn_channels)
-        self.output_conv_1 = _make_output_conv(fpn_channels)
+        # Step 4: 3×3 smoothing conv — reduces aliasing after addition
+        self.output_conv = nn.Sequential(
+            nn.Conv2d(fpn_channels, fpn_channels, kernel_size=3, padding=1, bias=False),
+            nn.GroupNorm(32, fpn_channels),
+            nn.GELU(),
+        )
 
-        # Final 1×1 projection: fpn_channels (192) → encoder_dim (512 or 768)
+        # Step 5: 1×1 projection — fpn_channels (384) → encoder_dim (512 or 768)
         self.proj = nn.Conv2d(fpn_channels, config.encoder_dim, kernel_size=1, bias=False)
 
-        # Stride-8 output: 256//8=32 height patches, 1280//8=160 width patches
-        num_patches_h = config.max_height // 8   # 32  (vertical / pitch)
-        num_patches_w = config.max_width // 8    # 160 (horizontal / time)
+        # Stride-16 output: 256//16=16 height patches, 1280//16=80 width patches
+        num_patches_h = config.max_height // 16  # 16 (vertical / pitch)
+        num_patches_w = config.max_width // 16   # 80 (horizontal / time)
 
         self.h_dim = config.encoder_h_dim
         self.w_dim = config.encoder_dim - self.h_dim
@@ -103,32 +94,29 @@ class ConvNeXtEncoder(nn.Module):
             p.requires_grad = True
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        _, stages = self.model.forward_intermediates(x, indices=[1, 2, 3])  # type: ignore
-        feat1 = stages[0]  # (B, 192, H/8,  W/8)
-        feat2 = stages[1]  # (B, 384, H/16, W/16)
-        feat3 = stages[2]  # (B, 768, H/32, W/32)
+        _, stages = self.model.forward_intermediates(x, indices=[2, 3])  # type: ignore
+        feat2 = stages[0]  # (B, 384, H/16, W/16) — stride-16, fine spatial detail
+        feat3 = stages[1]  # (B, 768, H/32, W/32) — stride-32, global context
 
-        # Step 1: lateral projections — all scales → 192ch
-        lat1 = self.lateral_stage1(feat1)
+        # Step 1: lateral projections → 384ch
         lat2 = self.lateral_stage2(feat2)
         lat3 = self.lateral_stage3(feat3)
 
-        # Step 2: top-down merge — feat3 into feat2 (stride 32 → 16)
-        # lat3 carries global context (clefs, key signatures, bar-level structure)
-        top_down_2 = F.interpolate(lat3, size=lat2.shape[-2:], mode="nearest")
-        fused2 = self.output_conv_2(lat2 + top_down_2)  # (B, 192, H/16, W/16)
+        # Step 2: upsample stride-32 → stride-16 using exact target size
+        top_down = F.interpolate(lat3, size=lat2.shape[-2:], mode="nearest")
 
-        # Step 3: top-down merge — fused feat2 into feat1 (stride 16 → 8)
-        # fused2 already carries feat3 signal, so feat3 context reaches stride-8 tokens
-        top_down_1 = F.interpolate(fused2, size=lat1.shape[-2:], mode="nearest")
-        fused1 = self.output_conv_1(lat1 + top_down_1)  # (B, 192, H/8, W/8)
+        # Step 3: element-wise addition — merge global context into spatial features
+        fused = lat2 + top_down
 
-        # Step 4: project to encoder_dim
-        fused = self.proj(fused1)  # (B, encoder_dim, H/8, W/8)
+        # Step 4: smooth aliasing from upsampling + addition
+        fused = self.output_conv(fused)  # (B, 384, H/16, W/16)
+
+        # Step 5: project to encoder_dim
+        fused = self.proj(fused)  # (B, encoder_dim, H/16, W/16)
 
         b, _c, h, w = fused.shape
 
-        # Factorized positional embeddings — separate h_dim + w_dim vectors per axis
+        # Factorized positional embeddings
         pos_h = self.pos_embed_h[:, :h, :].unsqueeze(2).expand(-1, -1, w, -1)
         pos_w = self.pos_embed_w[:, :w, :].unsqueeze(1).expand(-1, h, -1, -1)
         pos_embed = torch.cat([pos_h, pos_w], dim=-1)


### PR DESCRIPTION
@weixlu this an idea I toyed around with, but not sure how promising it is either. Feel free to give input.

The encoder's 3rd stage is currently unused. It produces feature maps at 1/16 spatial resolution (16x16 for a 256px input), which means coarse positional information - each "cell" covers a large receptive field. The 2nd stage runs at 1/8 (32x32), giving finer positional resolution but less semantic richness.

The idea is to fuse both via an FPN-style addition: you get the spatial precision of stage 2 and the richer, more abstract features of stage 3. In practice, it never worked well. It's unclear whether the concept itself is flawed here, or whether the implementation has an issue.