### PR TITLE
fix cross-staff arpeggios

### DIFF
--- a/tests/test_music_xml_parser.py
+++ b/tests/test_music_xml_parser.py
@@ -452,6 +452,64 @@ note_4 A4 _ slurStop upper&note_4 F4 # _ upper&note_4 B3 _ _ lower&note_4 D3 # _
 barline . . . ."""
         self.assertEqual(token_str, expected)
 
+    def test_arpeggiate(self) -> None:
+        """Arpeggio on one staff shouldn't be propagated to the other
+        one that starts on the same beat. It still should be filled in across
+        the chord notes on its own staff."""
+        self.maxDiff = None
+        # Upper-staff chord (no arpeggio) and lower-staff chord (arpeggio on
+        # one note only) sharing beat 0. like lc6810938.musicxml.
+        example = """<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>16</duration><voice>1</voice><type>whole</type><staff>1</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>D</step><octave>5</octave></pitch>
+        <duration>16</duration><voice>1</voice><type>whole</type><staff>1</staff>
+      </note>
+      <backup><duration>16</duration></backup>
+      <note>
+        <pitch><step>G</step><octave>2</octave></pitch>
+        <duration>16</duration><voice>5</voice><type>whole</type><staff>2</staff>
+        <notations><arpeggiate number="1"/></notations>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>D</step><octave>3</octave></pitch>
+        <duration>16</duration><voice>5</voice><type>whole</type><staff>2</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch><step>B</step><octave>3</octave></pitch>
+        <duration>16</duration><voice>5</voice><type>whole</type><staff>2</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+        tokens = music_xml_string_to_tokens(example)
+        flat_list = [x for xxs in tokens for xs in xxs for x in xs]
+        token_str = token_lines_to_str(flat_list)
+        expected = """clef_G2 _ _ _ upper&clef_F4 _ _ _ lower
+keySignature_0 . . . .
+timeSignature/4 . . . .
+note_1 D5 _ _ upper&note_1 D4 _ _ upper&note_1 B3 _ arpeggiate lower&note_1 D3 _ _ lower&note_1 G2 _ _ lower
+barline . . . ."""
+        self.assertEqual(token_str, expected)
+
     def _norm_expected(self, expected: str) -> str:
         norm = expected.replace("\n", "")
         norm = re.sub(r",\s+", ",", norm)

--- a/training/datasets/music_xml_parser.py
+++ b/training/datasets/music_xml_parser.py
@@ -164,32 +164,35 @@ class TokensMeasure:
             return "upper"
         return "lower"
 
-    def _fill_in_arpeggiate(self, symbols: list[EncodedSymbolWithPos]) -> None:
+    def _fill_in_arpeggiate(self, symbols_with_pos: list[EncodedSymbolWithPos]) -> None:
         """
         In the Lieder dataset we find that an arpeggiate always is rendered
         as it would affect all notes in a chord, even if the MusicXML doesn't
         reflect that.
         """
         arpegiatted_positions = set()
-        for symbol in symbols:
-            if "arpeggiate" in symbol.symbol.articulation:
-                arpegiatted_positions.add(symbol.position)
+        for entry in symbols_with_pos:
+            pos, sym = entry.position, entry.symbol
+            if "arpeggiate" in sym.articulation:
+                # `pos` is the position in the measure, `sym.position` is the upper/lower staff.
+                arpegiatted_positions.add((pos, sym.position))
 
-        for symbol in symbols:
+        for entry in symbols_with_pos:
+            pos, sym = entry.position, entry.symbol
             if (
-                symbol.position in arpegiatted_positions
-                and "arpeggiate" not in symbol.symbol.articulation
-                and symbol.symbol.rhythm.startswith(("note", "rest"))
-                and not symbol.symbol.rhythm.startswith("note_0")
-                and not symbol.symbol.rhythm.startswith("rest_0")
+                (pos, sym.position) in arpegiatted_positions
+                and "arpeggiate" not in sym.articulation
+                and sym.rhythm.startswith(("note", "rest"))
+                and not sym.rhythm.startswith("note_0")
+                and not sym.rhythm.startswith("rest_0")
             ):
-                art = symbol.symbol.articulation
+                art = sym.articulation
                 art_parts = []
                 if art != empty:
                     art_parts = art.split("_")
                 art_parts.append("arpeggiate")
                 art = str.join("_", sorted(art_parts))
-                symbol.symbol.articulation = art
+                sym.articulation = art
 
     def complete_measure(self) -> Measure:  # noqa: C901
         self._fill_in_arpeggiate(self.symbols)
@@ -228,13 +231,10 @@ class TupletState:
     def get_tuplet_factor(self, note: mxl.XMLNote, position: int) -> float:
         notations = note.get_children_of_type(mxl.XMLNotations)
         was_started = self.started or self.last_stop_position == position
-        if len(notations) > 0:
-            tuplets = notations[0].get_children_of_type(mxl.XMLTuplet)
-            print_object = notations[0].attributes.get("print-object", None)
-            for t in tuplets:
+        for notation in notations:
+            for t in notation.get_children_of_type(mxl.XMLTuplet):
                 t_type = t.attributes.get("type", None)
-                show_number = t.attributes.get("show-number", None)
-                if t_type == "start" and show_number != "none" and print_object != "no":
+                if t_type == "start":
                     self.started = True
                 if t_type == "stop":
                     self.started = False
@@ -408,47 +408,47 @@ def _collect_articulation(note: mxl.XMLNote, part: TokensPart, staff: int) -> st
     if not notations:
         return empty
     articulations = []
-    # pick the first articulation we support if multiple present
-    for child in notations[0].get_children():
-        print_object = child.attributes.get("print-object", None)
-        invisible = print_object == "no"
-        if isinstance(child, mxl.XMLArticulations) and not invisible:
-            for a in child.get_children():
-                if isinstance(child, mxl.XMLTremolo) and not invisible:
-                    tremolo_type = str(child.attributes.get("type", ""))
-                    part.tremolo = tremolo_type == "start"
-                else:
-                    name = a.__class__.__name__[
-                        3:
-                    ]  # strip XML prefix, e.g., XMLStaccato -> Staccato
-                    name = name[0].lower() + name[1:]
-                    if name in ARTIC_MAPPING:
-                        if ARTIC_MAPPING[name]:
-                            articulations.append(ARTIC_MAPPING[name])
+    for notation in notations:
+        for child in notation.get_children():
+            print_object = child.attributes.get("print-object", None)
+            invisible = print_object == "no"
+            if isinstance(child, mxl.XMLArticulations) and not invisible:
+                for a in child.get_children():
+                    if isinstance(child, mxl.XMLTremolo) and not invisible:
+                        tremolo_type = str(child.attributes.get("type", ""))
+                        part.tremolo = tremolo_type == "start"
                     else:
-                        articulations.append(name)
-        if isinstance(child, mxl.XMLFermata) and not invisible:
-            articulations.append("fermata")
-        if isinstance(child, mxl.XMLOrnaments) and not invisible:
-            for o in child.get_children():
-                nm = o.__class__.__name__[3:]
-                nm = nm[0].lower() + nm[1:]
-                if nm in ARTIC_MAPPING:
-                    if ARTIC_MAPPING[nm]:
-                        articulations.append(ARTIC_MAPPING[nm])
-                else:
-                    articulations.append(nm)
-        if isinstance(child, mxl.XMLTuplet):
-            # Tuplets are handled by TupletState
-            pass
-        if isinstance(child, mxl.XMLArpeggiate):
-            articulations.append("arpeggiate")
-        if isinstance(child, mxl.XMLTied):
-            tie_type = str(child.attributes.get("type", ""))
-            articulations.append("slur" + tie_type.capitalize())
-        if isinstance(child, mxl.XMLSlur):
-            slur_type = str(child.attributes.get("type", ""))
-            articulations.append("slur" + slur_type.capitalize())
+                        name = a.__class__.__name__[
+                            3:
+                        ]  # strip XML prefix, e.g., XMLStaccato -> Staccato
+                        name = name[0].lower() + name[1:]
+                        if name in ARTIC_MAPPING:
+                            if ARTIC_MAPPING[name]:
+                                articulations.append(ARTIC_MAPPING[name])
+                        else:
+                            articulations.append(name)
+            if isinstance(child, mxl.XMLFermata) and not invisible:
+                articulations.append("fermata")
+            if isinstance(child, mxl.XMLOrnaments) and not invisible:
+                for o in child.get_children():
+                    nm = o.__class__.__name__[3:]
+                    nm = nm[0].lower() + nm[1:]
+                    if nm in ARTIC_MAPPING:
+                        if ARTIC_MAPPING[nm]:
+                            articulations.append(ARTIC_MAPPING[nm])
+                    else:
+                        articulations.append(nm)
+            if isinstance(child, mxl.XMLTuplet):
+                # Tuplets are handled by TupletState
+                pass
+            if isinstance(child, mxl.XMLArpeggiate):
+                articulations.append("arpeggiate")
+            if isinstance(child, mxl.XMLTied):
+                tie_type = str(child.attributes.get("type", ""))
+                articulations.append("slur" + tie_type.capitalize())
+            if isinstance(child, mxl.XMLSlur):
+                slur_type = str(child.attributes.get("type", ""))
+                articulations.append("slur" + slur_type.capitalize())
 
     if part.tremolo:
         articulations.append("tremolo")


### PR DESCRIPTION
## Describe the Bug
Arpeggios spanning only one staff are incorrectly generated across both staves. The left one is ground truth, while the right one is generated.

<img width="226" height="205" alt="image" src="https://github.com/user-attachments/assets/084ceaef-c1af-4464-a3a6-368f04d9a7a5" />
- 
<img width="226" height="205" alt="image" src="https://github.com/user-attachments/assets/9c15dc91-4402-403c-aa19-251464c9a279" />

## Root Cause
The root cause is in dataset conversion. Take `lc6810938-1-2` from `datasets/Lieder-main/flat` for example, the arpeggio is in the lower voice.
<img width="1551" height="276" alt="image" src="https://github.com/user-attachments/assets/cbaf8907-047a-4453-990b-47b88edee105" />
But the `.tokens` shows arpeggiate in both upper and lower voice
```
barline . . . .
note_16 D5 _ arpeggiate upper&note_16 D4 _ _ upper&note_8 B3 b arpeggiate lower&note_8 D3 _ _ lower&note_8 G2 _ _ lower
note_16 D5 _ staccato upper&note_16 D4 _ _ upper
note_24 D5 _ _ upper&note_16 D4 _ _ upper
```
So the model learned from the dataset that, it should extend arpeggio to all staffs.

## Fix
So we need to fix dataset convertion. In `func _fill_in_arpeggiate()`, `arpegiatted_positions.add(symbol.position)` is not enough, because `symbol.position` just marks the beat(timestamp) of the note, while `symbol.symbol.position` is upper/lower voice of the note.
Theoretically this should be enough. I also add a test and it seems ok. But it still needs a retrain (which is in progress) and see if arpeggios are generated correctly.