### PR TITLE
Fix, sometimes grandstaffs weren't paired

### DIFF
--- a/homr/model.py
+++ b/homr/model.py
@@ -440,7 +440,7 @@ class MultiStaff(DebugDrawable):
 
         symbol_min_y = symbol.center[1] - symbol.size[1] / 2
         symbol_max_y = symbol.center[1] + symbol.size[1] / 2
-        y_overlap = min(symbol_max_y, lower_staff.max_y) - max(symbol_min_y, upper_staff.min_y)
+        y_overlap = abs(min(symbol_max_y, lower_staff.max_y) - max(symbol_min_y, upper_staff.min_y))
 
         if (
             x_distance < x_distance_threshold


### PR DESCRIPTION
Hi @weixlu , 

I have one case were the grandstaff detection doesn't work. It's two grandstaffs, but it only pairs the second one, so it runs the transformer with two individual staffs and a grandstaff. 

I'm just not sure if my fix makes sense :D. So I'd be happy to have your opinion. From my understanding y_overlap is a distance and so the abs part would be missing. I can also send you the image by mail if you want to take a look yourself. 

The fix would improve the benchmark results of https://github.com/liebharc/homr/pull/86#issuecomment-4698210995to `5.4 diffs, SER: 4.9%`