### PR TITLE
make empty staff visible in SVG

### DIFF
--- a/training/datasets/convert_lieder.py
+++ b/training/datasets/convert_lieder.py
@@ -124,7 +124,9 @@ def create_formats(source_file: str, formats: list[str]) -> list[dict[str, str]]
 
     # sq8940236: MuseScore seems to hang up
     # lc5001945: nested tuplet, not good for training
-    files_with_known_issues = ["sq8940236", "lc5001945"]
+    # lc6209608, lc6236149: empty&invisible staff in the very first system
+    # lc6162644: irregular staff in the last svg page
+    files_with_known_issues = ["sq8940236", "lc5001945", "lc6162644", "lc6209608", "lc6236149"]
     if any(issue in source_file for issue in files_with_known_issues):
         return jobs
     for target_format in formats:
@@ -192,6 +194,44 @@ def _make_tuplet_visible(mscx_file: str) -> None:
             f.write(new_content)
 
 
+def _make_staff_visible(mscx_file: str) -> None:
+    """
+    When rendering SVG, MuseScore can hide empty staff.
+    This will cause problem in SvgMusicFile.merge_voice_with_next_one(), because the merge procedure
+    assumes that all staffs are visible and deals with the staff one by one.
+
+    To avoid hiding empty staff, we need to change the following 3 settings:
+      * the global setting: <hideEmptyStaves>1</hideEmptyStaves>
+      * the per-staff setting: <hideWhenEmpty>1</hideWhenEmpty>
+      * <cutaway>1</cutaway>: this hides part of the staff, e.g. some empty measures.
+
+    Note: unfortunatelly, this does not cover every case.
+    lc6236149, lc6209608 still fails, so we just skip them.
+    """
+    with open(mscx_file, encoding="utf-8") as f:
+        content = f.read()
+
+    new_content = re.sub(
+        r"<hideEmptyStaves>1</hideEmptyStaves>",
+        "<hideEmptyStaves>0</hideEmptyStaves>",
+        content,
+    )
+    new_content = re.sub(
+        r"<hideWhenEmpty>1</hideWhenEmpty>",
+        "<hideWhenEmpty>0</hideWhenEmpty>",
+        new_content,
+    )
+    new_content = re.sub(
+        r"<cutaway>1</cutaway>",
+        "<cutaway>0</cutaway>",
+        new_content,
+    )
+
+    if new_content != content:
+        with open(mscx_file, "w", encoding="utf-8") as f:
+            f.write(new_content)
+
+
 def _create_musicxml_and_svg_files() -> None:
     dest = os.path.join(lieder, "flat")
     os.makedirs(dest, exist_ok=True)
@@ -205,6 +245,7 @@ def _create_musicxml_and_svg_files() -> None:
 
     for file in mscx_files:
         _make_tuplet_visible(str(file))
+        _make_staff_visible(str(file))
         jobs = create_formats(str(file), ["musicxml", "svg"])
         all_jobs.extend(jobs)
 


### PR DESCRIPTION
## Describe the bug
when running `training/datasets/convert_lieder.py`, this message (`Can't merge staffs with a different number of measures`) shows up 108 times, and this PR is intend to fix this. 
## Root Cause
This info appears when 2 staffs are paired incorrectly, thus can't be merged. The pair and merge procedure is done in `SvgMusicFile.merge_voice_with_next_one()`, it deals with the staff one by one, and relies on the assumption that all staffs are visible.
In fact, when rendering SVG, MuseScore can hide empty staff. For example, `datasets/Lieder-main/flat/lc5054946-4.svg`
<img width="570" height="464" alt="image" src="https://github.com/user-attachments/assets/d919a242-226e-4bba-9f2a-f9f4985e0a3a" />
## Expected result
To make `merge_voice_with_next_one()` works as expected, we need to make empty staff visible. After this PR is implemented, this image look like(Let's skip the first system, and only show the second one, e.g. measure14):

lc5054946-4-3.png:
<img width="1919" height="115" alt="image" src="https://github.com/user-attachments/assets/5c50bb7c-006a-4a73-be95-bad7ddcb5004" />

lc5054946-4-3.tokens
```
clef_G2 _ _ _ _ upper
keySignature_2 . . . . .
rest_2. _ _ _ _ upper
barline . . . . .
```

lc5054946-4-4.png:
<img width="1925" height="395" alt="image" src="https://github.com/user-attachments/assets/5dd3c62f-25ff-47ff-b52b-a697f0ea5a86" />


## How to fix
Just like what we have done in #94 , we need to change the 2 setting:
- the global setting: `<hideEmptyStaves>1</hideEmptyStaves>`
- the per-staff setting: `<hideWhenEmpty>1</hideWhenEmpty>`

Especially, there is a `cutaway` setting, which just hides part of the staff, e.g. some empty measures. Take `datasets/Lieder-main/flat/lc6623221-4.svg` for example
<img width="677" height="211" alt="image" src="https://github.com/user-attachments/assets/bdf32ad5-664b-49fb-8ff5-178a913f0910" />
Solution for this case is similar, we simply discard the `cutaway` setting.

Unfortunatelly, the methods above do not cover every case. lc6236149, lc6209608 still fails, so we just skip them. And `datasets/Lieder-main/flat/lc6162644-2.svg` looks quite weird, I suggest skip it too. 
<img width="574" height="394" alt="image" src="https://github.com/user-attachments/assets/28038679-a3ae-4603-b0db-a1f09d8d6ec4" />

After all these fix, finally we only see this message `Can't merge staffs...` once in `lc6248301.musicxml`. I haven't seen it deeper, this sheet looks no-problem, not sure where is the root cause.