### PR TITLE
Use the key ideas from Transcoda: Synthetic datasets and better data augmentations

### DIFF
--- a/Training.md
+++ b/Training.md
@@ -77,6 +77,19 @@ This validation provides a **more representative indication of overall system pe
 
 Implementation: `rate_validation_result.py`
 
+## Run 426 - 27 epochs
+
+Commit: b6fd20809a8dcaf10dfd39a4ca4f64c6f056e644
+Day: 13 July 2026
+Transformer Smoke Test: 5%
+System Level: Total: 5.7 diffs, SER: 4.2%
+System Level after adding https://github.com/liebharc/homr/issues/110: Total: 5.5 diffs, SER: 4.1%
+Polish scores: OMR-NED 24.30%
+
+Training with lieder+grandstaff+primux+pdmx+musetrainer datasets.
+
+Note that https://github.com/liebharc/homr/issues/110 will from now on remain in the system level datset to avoid regressions.
+
 ## Run 414
 
 Commit: 79aec9b6b66de2281972c9d4f9c606f3f84c9cd1

--- a/Training.md
+++ b/Training.md
@@ -77,6 +77,16 @@ This validation provides a **more representative indication of overall system pe
 
 Implementation: `rate_validation_result.py`
 
+## Run 410 - at epoch 7
+
+Commit: 23c9006d8f23b8f178b5c7ee64bb9cb430c4d7bc
+Day: 03 July 2026
+Transformer Smoke Test: 12%
+System Level: 10.6 diffs, SER: 6.4%
+Polish scores with musicdiff: OMR-NED 47.3%
+
+Quick training run after updating data augmentation.
+
 ## Run 407 - at epoch 6
 
 Commit: fabab4b0f8480be20d13686edf5f91d913ab00fd

--- a/homr/main.py
+++ b/homr/main.py
@@ -2,6 +2,7 @@ import argparse
 import glob
 import os
 import sys
+import xml.etree.ElementTree as ET
 from concurrent.futures import Future
 from dataclasses import dataclass
 from enum import Enum
@@ -209,7 +210,7 @@ def process_image(
 
         eprint("Writing XML", result_staffs)
         xml = generate_xml(xml_generator_args, result_staffs, title)
-        xml.write(xml_file)
+        ET.ElementTree(xml).write(xml_file, encoding="unicode", xml_declaration=True)
 
         eprint("Finished parsing " + str(len(result_staffs)) + " staves")
         teaser_file = replace_extension(image_path, "_teaser.png")

--- a/homr/music_xml_generator.py
+++ b/homr/music_xml_generator.py
@@ -1,9 +1,9 @@
 import math
+import xml.etree.ElementTree as ET
 from collections import defaultdict
 from dataclasses import dataclass
 from fractions import Fraction
 
-import musicxml.xmlelement.xmlelement as mxl
 import numpy as np
 
 from homr import constants
@@ -98,27 +98,29 @@ class XmlGeneratorArguments:
         self.tempo = tempo
 
 
-def build_identification() -> mxl.XMLIdentification:
-    """Identification/encoding so validators and apps (e.g. MuseScore) can attribute the file."""
-    ident = mxl.XMLIdentification()
-    enc = mxl.XMLEncoding()
-    enc.add_child(mxl.XMLSoftware(value_="homr"))
-    ident.add_child(enc)
+def build_identification() -> ET.Element:
+    ident = ET.Element("identification")
+    enc = ET.SubElement(ident, "encoding")
+    ET.SubElement(enc, "software").text = "homr"
     return ident
 
 
 def generate_xml(
     args: XmlGeneratorArguments, staffs: list[list[EncodedSymbol]], title: str
-) -> mxl.XMLElement:
-    root = mxl.XMLScorePartwise(version="4.0")
-    root.add_child(build_work(title))
-    root.add_child(build_identification())
-    root.add_child(build_defaults(args))
+) -> ET.Element:
+    root = ET.Element("score-partwise", version="4.0")
+    root.append(build_work(title))
+    root.append(build_identification())
+    root.append(build_defaults(args))
     has_two_staves_by_part = [_voice_has_two_staves(staff) for staff in staffs]
-    root.add_child(build_part_list(has_two_staves_by_part))
+    root.append(build_part_list(has_two_staves_by_part))
     for index, staff in enumerate(staffs):
-        root.add_child(build_part(args, staff, index, has_two_staves_by_part[index]))
+        root.append(build_part(args, staff, index, has_two_staves_by_part[index]))
     return root
+
+
+def xml_to_string(element: ET.Element) -> str:
+    return ET.tostring(element, encoding="unicode")
 
 
 def _voice_has_two_staves(voice: list[EncodedSymbol]) -> bool:
@@ -128,12 +130,11 @@ def _voice_has_two_staves(voice: list[EncodedSymbol]) -> bool:
 
 def build_part(
     args: XmlGeneratorArguments, voice: list[EncodedSymbol], index: int, has_two_staves: bool
-) -> mxl.XMLPart:
-    part = mxl.XMLPart(id=get_part_id(index))
+) -> ET.Element:
+    part = ET.Element("part", id=get_part_id(index))
     is_first_part = index == 0
-    measures = build_measures(args, voice, is_first_part, has_two_staves)
-    for measure in measures:
-        part.add_child(measure)
+    for measure in build_measures(args, voice, is_first_part, has_two_staves):
+        part.append(measure)
     return part
 
 
@@ -142,7 +143,7 @@ def build_measures(
     voice: list[EncodedSymbol],
     is_first_part: bool,
     has_two_staves: bool = False,
-) -> list[mxl.XMLMeasure]:
+) -> list[ET.Element]:
     def close_current_measure() -> None:
         rebalance_measure_voices(current_measure)
         measures.append(current_measure)
@@ -151,18 +152,18 @@ def build_measures(
     groups = add_tuplet_start_stop(group_into_chords(voice))
     division, nominator = find_division_and_time_signature_nominator(groups)
     state = ConversionState(division, nominator)
-    measures: list[mxl.XMLMeasure] = []
-    current_measure = mxl.XMLMeasure(number=str(measure_number))
+    measures: list[ET.Element] = []
+    current_measure = ET.Element("measure", number=str(measure_number))
     first_attributes = build_or_get_attributes(current_measure, None)
-    first_attributes.add_child(build_divisions(division))
+    ET.SubElement(first_attributes, "divisions").text = str(division // 4)
     if has_two_staves:
-        first_attributes.add_child(mxl.XMLStaves(value_=2))
-        first_attributes.add_child(mxl.XMLPartSymbol(value_="brace"))
+        ET.SubElement(first_attributes, "staves").text = "2"
+        ET.SubElement(first_attributes, "part-symbol").text = "brace"
     if is_first_part:
         direction = build_add_time_direction(args)
-        if direction:
-            current_measure.add_child(direction)
-    attributes: mxl.XMLAttributes | None = first_attributes
+        if direction is not None:
+            current_measure.append(direction)
+    attributes: ET.Element | None = first_attributes
     for group_no, group in enumerate(groups):
         symbol = group.symbols[0]
         rhythm = symbol.rhythm
@@ -179,12 +180,12 @@ def build_measures(
                         group.get_duration() if pos_no == len(staff_positions) - 1 else Fraction(0)
                     )
                     for note_xml in build_note_chord(staff_pos, state, chord_duration):
-                        current_measure.add_child(note_xml)
+                        current_measure.append(note_xml)
             continue
         if rhythm == "newline":
             is_last_measure = group_no == len(groups) - 1
             if not is_last_measure:
-                current_measure.add_child(mxl.XMLPrint(new_system="yes"))
+                ET.SubElement(current_measure, "print", attrib={"new-system": "yes"})
         elif rhythm.startswith("clef"):
             attributes = build_or_get_attributes(current_measure, last_attributes, force_new=True)
             for should_be_clef in group.symbols:
@@ -198,17 +199,16 @@ def build_measures(
             build_time_signature(symbol, attributes, state)
         elif "barline" in rhythm:
             if rhythm != "barline":
-                # Standard barlines don't need extra handling
                 barline = build_or_get_barline(current_measure, "right")
                 build_barline_style(symbol, barline)
 
             close_current_measure()
             measure_number += 1
-            current_measure = mxl.XMLMeasure(number=str(measure_number))
+            current_measure = ET.Element("measure", number=str(measure_number))
         elif rhythm == "repeatStart":
             close_current_measure()
             measure_number += 1
-            current_measure = mxl.XMLMeasure(number=str(measure_number))
+            current_measure = ET.Element("measure", number=str(measure_number))
 
             barline = build_or_get_barline(current_measure, "right")
             build_repeat(symbol, barline)
@@ -218,14 +218,14 @@ def build_measures(
 
             close_current_measure()
             measure_number += 1
-            current_measure = mxl.XMLMeasure(number=str(measure_number))
+            current_measure = ET.Element("measure", number=str(measure_number))
         elif rhythm == "repeatEndStart":
             barline = build_or_get_barline(current_measure, "right")
             build_repeat(EncodedSymbol("repeatEnd"), barline)
 
             close_current_measure()
             measure_number += 1
-            current_measure = mxl.XMLMeasure(number=str(measure_number))
+            current_measure = ET.Element("measure", number=str(measure_number))
             barline = build_or_get_barline(current_measure, "right")
             build_repeat(EncodedSymbol("repeatStart"), barline)
         elif rhythm.startswith("voltaStart"):
@@ -239,35 +239,28 @@ def build_measures(
         else:
             eprint("Symbol isn't supported yet ", symbol)
 
-    if len(current_measure.get_children()) > 0:
+    if len(list(current_measure)) > 0:
         close_current_measure()
+    if first_attributes.find("time") is None:
+        time_el = ET.SubElement(first_attributes, "time")
+        beats = max(int(state.nominator * 4), 1)
+        ET.SubElement(time_el, "beats").text = str(beats)
+        ET.SubElement(time_el, "beat-type").text = "4"
     return measures
 
 
-def build_work(title_text: str) -> mxl.XMLWork:
-    work = mxl.XMLWork()
-    title = mxl.XMLWorkTitle()
-    title._value = title_text
-    work.add_child(title)
+def build_work(title_text: str) -> ET.Element:
+    work = ET.Element("work")
+    ET.SubElement(work, "work-title").text = title_text
     return work
 
 
-def build_defaults(args: XmlGeneratorArguments) -> mxl.XMLDefaults:
-    if not args.large_page:
-        return mxl.XMLDefaults()
-    # These values are larger than a letter or A4 format so that
-    # we only have to break staffs with every new detected staff
-    # This works well for electronic formats, if the results are supposed
-    # to get printed then they might need to be scaled down to fit the page
-    page_width = 110  # Unit is in tenths: https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/page-height/
-    page_height = 300
-    defaults = mxl.XMLDefaults()
-    page_layout = mxl.XMLPageLayout()
-    page_height = mxl.XMLPageHeight(value_=page_height)
-    page_width = mxl.XMLPageWidth(value_=page_width)
-    page_layout.add_child(page_height)
-    page_layout.add_child(page_width)
-    defaults.add_child(page_layout)
+def build_defaults(args: XmlGeneratorArguments) -> ET.Element:
+    defaults = ET.Element("defaults")
+    if args.large_page:
+        page_layout = ET.SubElement(defaults, "page-layout")
+        ET.SubElement(page_layout, "page-height").text = "300"
+        ET.SubElement(page_layout, "page-width").text = "110"
     return defaults
 
 
@@ -288,60 +281,44 @@ def _part_metadata(has_two_staves: bool) -> tuple[str, str, str, int]:
     return ("Voice", "Voice", "voice", 54)
 
 
-def build_part_list(has_two_staves_by_part: list[bool]) -> mxl.XMLPartList:
-    part_list = mxl.XMLPartList()
+def build_part_list(has_two_staves_by_part: list[bool]) -> ET.Element:
+    part_list = ET.Element("part-list")
     for part, has_two_staves in enumerate(has_two_staves_by_part):
         part_id = get_part_id(part)
         part_name_str, instrument_name_str, instrument_sound_str, midi_program = _part_metadata(
             has_two_staves
         )
-        score_part = mxl.XMLScorePart(id=part_id)
-        part_name = mxl.XMLPartName(value_=part_name_str)
-        score_part.add_child(part_name)
-        score_instrument = mxl.XMLScoreInstrument(id=part_id + "-I1")
-        instrument_name = mxl.XMLInstrumentName(value_=instrument_name_str)
-        score_instrument.add_child(instrument_name)
-        instrument_sound = mxl.XMLInstrumentSound(value_=instrument_sound_str)
-        score_instrument.add_child(instrument_sound)
-        score_part.add_child(score_instrument)
-        midi_instrument = mxl.XMLMidiInstrument(id=part_id + "-I1")
-        midi_instrument.add_child(mxl.XMLMidiChannel(value_=part + 1))
-        midi_instrument.add_child(mxl.XMLMidiProgram(value_=midi_program))
-        midi_instrument.add_child(mxl.XMLVolume(value_=100))
-        midi_instrument.add_child(mxl.XMLPan(value_=0))
-        score_part.add_child(midi_instrument)
-        part_list.add_child(score_part)
+        score_part = ET.SubElement(part_list, "score-part", id=part_id)
+        ET.SubElement(score_part, "part-name").text = part_name_str
+        score_instrument = ET.SubElement(score_part, "score-instrument", id=part_id + "-I1")
+        ET.SubElement(score_instrument, "instrument-name").text = instrument_name_str
+        ET.SubElement(score_instrument, "instrument-sound").text = instrument_sound_str
+        midi_instrument = ET.SubElement(score_part, "midi-instrument", id=part_id + "-I1")
+        ET.SubElement(midi_instrument, "midi-channel").text = str(part + 1)
+        ET.SubElement(midi_instrument, "midi-program").text = str(midi_program)
+        ET.SubElement(midi_instrument, "volume").text = "100"
+        ET.SubElement(midi_instrument, "pan").text = "0"
     return part_list
 
 
 def build_or_get_attributes(
-    measure: mxl.XMLMeasure, last_attributes: mxl.XMLAttributes | None, force_new: bool = False
-) -> mxl.XMLAttributes:
+    measure: ET.Element, last_attributes: ET.Element | None, force_new: bool = False
+) -> ET.Element:
     if last_attributes is not None and not force_new:
         return last_attributes
-
-    attributes = mxl.XMLAttributes()
-    measure.add_child(attributes)
-    return attributes
+    return ET.SubElement(measure, "attributes")
 
 
-def build_or_get_barline(measure: mxl.XMLMeasure, location: str) -> mxl.XMLBarline:
-    children = measure.get_children_of_type(mxl.XMLBarline)
-    for child in children:
-        if child.location == location:
+def build_or_get_barline(measure: ET.Element, location: str) -> ET.Element:
+    for child in measure:
+        if child.tag == "barline" and child.get("location") == location:
             return child
-
-    barline = mxl.XMLBarline(location=location)
-    measure.add_child(barline)
-    return barline
+    return ET.SubElement(measure, "barline", location=location)
 
 
-def build_key(model_key: EncodedSymbol, attributes: mxl.XMLAttributes) -> None:
-    key = mxl.XMLKey()
-    circle_of_fifth = model_key.rhythm.split("_")[1]
-    fifth = mxl.XMLFifths(value_=int(circle_of_fifth))
-    attributes.add_child(key)
-    key.add_child(fifth)
+def build_key(model_key: EncodedSymbol, attributes: ET.Element) -> None:
+    key = ET.SubElement(attributes, "key")
+    ET.SubElement(key, "fifths").text = model_key.rhythm.split("_")[1]
 
 
 def get_staff(symbol: EncodedSymbol) -> int:
@@ -363,33 +340,33 @@ class TimedNoteEvent:
     staff_num: int
     start: int
     end: int
-    notes: list[mxl.XMLNote]
+    notes: list[ET.Element]
 
 
-def rebalance_measure_voices(measure: mxl.XMLMeasure) -> None:
+def rebalance_measure_voices(measure: ET.Element) -> None:
     """Assign stable non-overlapping voices per staff for a whole measure."""
     timed_events: list[TimedNoteEvent] = []
     current_time = 0
     last_note_start = 0
-    for child in measure.get_children():
-        if isinstance(child, mxl.XMLBackup):
-            durations = child.get_children_of_type(mxl.XMLDuration)
-            if len(durations) > 0:
-                current_time -= int(durations[0].value_)
+    for child in measure:
+        if child.tag == "backup":
+            dur = child.find("duration")
+            if dur is not None:
+                current_time -= int(dur.text)  # type: ignore[arg-type]
             continue
-        if child.__class__.__name__ == "XMLForward":
-            durations = child.get_children_of_type(mxl.XMLDuration)
-            if len(durations) > 0:
-                current_time += int(durations[0].value_)
+        if child.tag == "forward":
+            dur = child.find("duration")
+            if dur is not None:
+                current_time += int(dur.text)  # type: ignore[arg-type]
             continue
-        if not isinstance(child, mxl.XMLNote):
+        if child.tag != "note":
             continue
 
-        duration_nodes = child.get_children_of_type(mxl.XMLDuration)
-        duration = int(duration_nodes[0].value_) if len(duration_nodes) > 0 else 0
-        staff_nodes = child.get_children_of_type(mxl.XMLStaff)
-        staff_num = int(staff_nodes[0].value_) if len(staff_nodes) > 0 else 1
-        is_chord_tone = len(child.get_children_of_type(mxl.XMLChord)) > 0
+        dur_el = child.find("duration")
+        duration = int(dur_el.text) if dur_el is not None else 0  # type: ignore[arg-type]
+        staff_el = child.find("staff")
+        staff_num = int(staff_el.text) if staff_el is not None else 1  # type: ignore[arg-type]
+        is_chord_tone = child.find("chord") is not None
         start = last_note_start if is_chord_tone else current_time
         end = start + duration
         if is_chord_tone and (
@@ -412,7 +389,7 @@ def rebalance_measure_voices(measure: mxl.XMLMeasure) -> None:
 
     for staff_num, events in by_staff.items():
         sorted_events = sorted(events, key=lambda e: (e.start, e.end))
-        active: list[tuple[int, int]] = []  # (end, local voice number 1..n)
+        active: list[tuple[int, int]] = []
         for event in sorted_events:
             active = [
                 (active_end, voice_no)
@@ -426,61 +403,52 @@ def rebalance_measure_voices(measure: mxl.XMLMeasure) -> None:
             active.append((event.end, voice_no))
             xml_voice = str(get_xml_voice(staff_num, voice_no - 1))
             for note in event.notes:
-                voice_nodes = note.get_children_of_type(mxl.XMLVoice)
-                if len(voice_nodes) > 0:
-                    voice_nodes[0].value_ = xml_voice
+                voice_el = note.find("voice")
+                if voice_el is not None:
+                    voice_el.text = xml_voice
 
 
-def build_clef(model_clef: EncodedSymbol, attributes: mxl.XMLAttributes) -> None:
+def build_clef(model_clef: EncodedSymbol, attributes: ET.Element) -> None:
     sign_and_line = model_clef.rhythm.split("_")[1]
-    sign = sign_and_line[0]
-    line = sign_and_line[1]
-    clef = mxl.XMLClef(number=get_staff(model_clef))
-    attributes.add_child(clef)
-    clef.add_child(mxl.XMLSign(value_=sign))
-    clef.add_child(mxl.XMLLine(value_=int(line)))
+    clef = ET.SubElement(attributes, "clef", number=str(get_staff(model_clef)))
+    ET.SubElement(clef, "sign").text = sign_and_line[0]
+    ET.SubElement(clef, "line").text = sign_and_line[1]
 
 
 def build_time_signature(
-    model_time_signature: EncodedSymbol, attributes: mxl.XMLAttributes, state: ConversionState
+    model_time_signature: EncodedSymbol, attributes: ET.Element, state: ConversionState
 ) -> None:
-    time = mxl.XMLTime()
-
+    time = ET.SubElement(attributes, "time")
     denominator = model_time_signature.rhythm.split("/")[1]
-    attributes.add_child(time)
     beats = max(int(state.nominator * int(denominator)), 1)
-    time.add_child(mxl.XMLBeats(value_=str(beats)))
-    time.add_child(mxl.XMLBeatType(value_=denominator))
+    ET.SubElement(time, "beats").text = str(beats)
+    ET.SubElement(time, "beat-type").text = denominator
     state.beats = beats
 
 
-def build_barline_style(barline: EncodedSymbol, xml: mxl.XMLBarline) -> None:
+def build_barline_style(barline: EncodedSymbol, xml: ET.Element) -> None:
     style_value = "heavy-heavy" if barline.rhythm == "bolddoublebarline" else "light-light"
-    style = mxl.XMLBarStyle(value_=style_value)
-    xml.add_child(style)
+    ET.SubElement(xml, "bar-style").text = style_value
 
 
-def build_barline_ending(volta: EncodedSymbol, xml: mxl.XMLBarline, volta_number: int) -> None:
+def build_barline_ending(volta: EncodedSymbol, xml: ET.Element, volta_number: int) -> None:
     if volta.rhythm.startswith("voltaStart"):
-        ending = mxl.XMLEnding(type="start", number=str(volta_number))
+        type_ = "start"
     elif volta.rhythm.startswith("voltaStop"):
-        ending = mxl.XMLEnding(type="stop", number=str(volta_number))
+        type_ = "stop"
     elif volta.rhythm.startswith("voltaDiscontinue"):
-        ending = mxl.XMLEnding(type="discontinue", number=str(volta_number))
+        type_ = "discontinue"
     else:
         raise ValueError("Unknown ending " + str(volta))
-    xml.add_child(ending)
+    ET.SubElement(xml, "ending", type=type_, number=str(volta_number))
 
 
-def build_repeat(barline: EncodedSymbol, xml: mxl.XMLBarline) -> None:
-    if len(xml.get_children_of_type(mxl.XMLRepeat)) > 0:
+def build_repeat(barline: EncodedSymbol, xml: ET.Element) -> None:
+    if xml.find("repeat") is not None:
         eprint("barline already has a repeat")
         return
-
-    repeat = mxl.XMLRepeat()
     direction = "forward" if barline.rhythm == "repeatStart" else "backward"
-    repeat._set_attributes({"direction": direction})
-    xml.add_child(repeat)
+    ET.SubElement(xml, "repeat", direction=direction)
 
 
 LIFT_TO_ALTER = {
@@ -505,13 +473,12 @@ DURATION_NAMES = {
 
 
 def build_articulations(
-    note: mxl.XMLNote, articualations: str, tuplet_mark: str, state: ConversionState
+    note: ET.Element, articualations: str, tuplet_mark: str, state: ConversionState
 ) -> None:
-    notation = mxl.XMLNotations()
-    note.add_child(notation)
+    notation = ET.SubElement(note, "notations")
 
-    xml_articulations = []
-    xml_ornaments = []
+    xml_articulations: list[ET.Element] = []
+    xml_ornaments: list[ET.Element] = []
 
     for articulation in articualations.split("_"):
         if articulation == "":
@@ -519,82 +486,72 @@ def build_articulations(
         elif articulation == nonote:
             eprint("WARNING note without valid articulation", articualations)
         elif articulation == "fermata":
-            notation.add_child(mxl.XMLFermata())
+            ET.SubElement(notation, "fermata")
         elif articulation == "arpeggiate":
-            notation.add_child(mxl.XMLArpeggiate())
+            ET.SubElement(notation, "arpeggiate")
         elif articulation == "accent":
-            xml_articulations.append(mxl.XMLAccent())
-        elif articulation == "arpeggiate":
-            notation.add_child(mxl.XMLArpeggiate())
-        elif articulation == "fermata":
-            xml_articulations.append(mxl.XMLFermata())
+            xml_articulations.append(ET.Element("accent"))
         elif articulation == "staccato":
-            xml_articulations.append(mxl.XMLStaccato())
+            xml_articulations.append(ET.Element("staccato"))
         elif articulation == "staccatissimo":
-            xml_articulations.append(mxl.XMLStaccatissimo())
+            xml_articulations.append(ET.Element("staccatissimo"))
         elif articulation == "tenuto":
-            xml_articulations.append(mxl.XMLTenuto())
+            xml_articulations.append(ET.Element("tenuto"))
         elif articulation == "tremolo":
-            xml_ornaments.append(mxl.XMLTremolo(value_=3, type=state.toggle_tremolo_state()))
+            el = ET.Element("tremolo", type=state.toggle_tremolo_state())
+            el.text = "3"
+            xml_ornaments.append(el)
         elif articulation == "trill":
-            xml_ornaments.append(mxl.XMLTrillMark())
+            xml_ornaments.append(ET.Element("trill-mark"))
         elif articulation == "breathMark":
-            xml_articulations.append(mxl.XMLBreathMark())
+            xml_articulations.append(ET.Element("breath-mark"))
         elif articulation == "turn":
-            xml_ornaments.append(mxl.XMLInvertedTurn())
+            xml_ornaments.append(ET.Element("inverted-turn"))
         elif articulation == "caesura":
-            xml_articulations.append(mxl.XMLCaesura())
+            xml_articulations.append(ET.Element("caesura"))
         elif articulation == "doit":
-            xml_articulations.append(mxl.XMLDoit())
+            xml_articulations.append(ET.Element("doit"))
         elif articulation == "slurStart":
-            notation.add_child(mxl.XMLSlur(type="start"))
+            ET.SubElement(notation, "slur", type="start")
         elif articulation == "slurStop":
-            notation.add_child(mxl.XMLSlur(type="stop"))
+            ET.SubElement(notation, "slur", type="stop")
         elif articulation == "tieStart":
-            notation.add_child(mxl.XMLTied(type="start"))
+            ET.SubElement(notation, "tied", type="start")
         elif articulation == "tieStop":
-            notation.add_child(mxl.XMLTied(type="stop"))
+            ET.SubElement(notation, "tied", type="stop")
         else:
             raise ValueError("Unsupported articulation " + articulation)
 
     if tuplet_mark != "":
-        tuplet_xml = mxl.XMLTuplet(type=tuplet_mark)
-        notation.add_child(tuplet_xml)
+        ET.SubElement(notation, "tuplet", type=tuplet_mark)
 
-    if len(xml_articulations) > 0:
-        parent = mxl.XMLArticulations()
+    if xml_articulations:
+        parent = ET.SubElement(notation, "articulations")
         for child in xml_articulations:
-            parent.add_child(child)
-        notation.add_child(parent)
+            parent.append(child)
 
-    if len(xml_ornaments) > 0:
-        parent = mxl.XMLOrnaments()
+    if xml_ornaments:
+        parent = ET.SubElement(notation, "ornaments")
         for child in xml_ornaments:
-            parent.add_child(child)
-        notation.add_child(parent)
+            parent.append(child)
 
 
-def build_slurs(note: mxl.XMLNote, slurs: str, slur_number: int) -> None:
-    notations = note.get_children_of_type(mxl.XMLNotations)
-    if notations:
-        notation = notations[0]
-    else:
-        notation = mxl.XMLNotations()
-        note.add_child(notation)
+def build_slurs(note: ET.Element, slurs: str, slur_number: int) -> None:
+    notation = note.find("notations")
+    if notation is None:
+        notation = ET.SubElement(note, "notations")
 
     if slurs in {"_", ""}:
         pass
     elif slurs == nonote:
         eprint("WARNING note without valid articulation", slurs)
     elif slurs == "slurStart":
-        notation.add_child(mxl.XMLSlur(type="start", number=slur_number))
+        ET.SubElement(notation, "slur", type="start", number=str(slur_number))
     elif slurs == "slurStop":
-        notation.add_child(mxl.XMLSlur(type="stop", number=slur_number))
+        ET.SubElement(notation, "slur", type="stop", number=str(slur_number))
     elif slurs == "slurStart_slurStop":
-        # It is important to first add the stop and than the start
-        # otherwise the slur starts and directly stops
-        notation.add_child(mxl.XMLSlur(type="stop", number=slur_number))
-        notation.add_child(mxl.XMLSlur(type="start", number=slur_number))
+        ET.SubElement(notation, "slur", type="stop", number=str(slur_number))
+        ET.SubElement(notation, "slur", type="start", number=str(slur_number))
     else:
         raise ValueError("Unsupported slur " + slurs)
 
@@ -605,104 +562,97 @@ def build_note_or_rest(
     is_chord: bool,
     state: ConversionState,
     tuplet_mark: str,
-) -> mxl.XMLNote:
-    note = mxl.XMLNote()
+) -> ET.Element:
+    note = ET.Element("note")
     if is_chord:
-        note.add_child(mxl.XMLChord())
+        ET.SubElement(note, "chord")
     model_pitch = model_note.pitch
     model_duration = model_note.get_duration()
+
+    if "G" in model_note.rhythm:
+        ET.SubElement(note, "grace")
+
     if model_pitch == empty:
         if model_duration.fraction.numerator == 0:
-            note.add_child(mxl.XMLRest(measure="yes"))
+            ET.SubElement(note, "rest", measure="yes")
         else:
-            note.add_child(mxl.XMLRest())
+            ET.SubElement(note, "rest")
     elif model_pitch == nonote:
         eprint("WARNING note without pitch", model_note)
-        note.add_child(mxl.XMLRest())
+        ET.SubElement(note, "rest")
     else:
-        pitch = mxl.XMLPitch()
-        pitch.add_child(mxl.XMLStep(value_=model_pitch[0]))
-        pitch.add_child(mxl.XMLOctave(value_=int(model_pitch[1])))
+        pitch = ET.SubElement(note, "pitch")
+        ET.SubElement(pitch, "step").text = model_pitch[0]
+        ET.SubElement(pitch, "octave").text = model_pitch[1]
         if model_note.lift == nonote:
             eprint("WARNING note with invalid lift", model_note)
         elif model_note.lift != empty:
-            pitch.add_child(mxl.XMLAlter(value_=LIFT_TO_ALTER[model_note.lift]))
-        note.add_child(pitch)
+            ET.SubElement(pitch, "alter").text = str(LIFT_TO_ALTER[model_note.lift])
 
     if "G" in model_note.rhythm:
-        note.add_child(mxl.XMLGrace())
         base_duration = model_duration.kern
-        duration_name = DURATION_NAMES[base_duration]
-        note.add_child(mxl.XMLType(value_=duration_name))
+        ET.SubElement(note, "type").text = DURATION_NAMES[base_duration]
     elif model_duration.fraction.numerator > 0:
         base_duration = 1 if model_duration.kern == 0 else model_duration.kern
-        duration_name = DURATION_NAMES[base_duration]
-        note.add_child(mxl.XMLType(value_=duration_name))
-        note.add_child(mxl.XMLDuration(value_=int(model_duration.fraction * state.division)))
+        ET.SubElement(note, "duration").text = str(int(model_duration.fraction * state.division))
+        ET.SubElement(note, "type").text = DURATION_NAMES[base_duration]
     else:
-        duration_name = DURATION_NAMES[0]
-        note.add_child(mxl.XMLType(value_=duration_name))
-        note.add_child(mxl.XMLDuration(value_=state.beats))
+        ET.SubElement(note, "duration").text = str(state.beats)
+        ET.SubElement(note, "type").text = DURATION_NAMES[0]
+
+    for _ in range(model_duration.dots):
+        ET.SubElement(note, "dot")
+
+    if model_duration.actual_notes != model_duration.normal_notes:
+        time_mod = ET.SubElement(note, "time-modification")
+        ET.SubElement(time_mod, "actual-notes").text = str(model_duration.actual_notes)
+        ET.SubElement(time_mod, "normal-notes").text = str(model_duration.normal_notes)
 
     staff_num = get_staff(model_note)
     slur_number = staff_num
-    note.add_child(mxl.XMLStaff(value_=staff_num))
-    note.add_child(mxl.XMLVoice(value_=str(get_xml_voice(staff_num, rhythmic_layer))))
-    for _ in range(model_duration.dots):
-        note.add_child(mxl.XMLDot())
-    if model_duration.actual_notes != model_duration.normal_notes:
-        time_modification = mxl.XMLTimeModification()
-        time_modification.add_child(mxl.XMLActualNotes(value_=model_duration.actual_notes))
-        time_modification.add_child(mxl.XMLNormalNotes(value_=model_duration.normal_notes))
-        note.add_child(time_modification)
-        build_articulations(note, model_note.articulation, tuplet_mark, state)
-        build_slurs(note, model_note.slur, slur_number)
-    else:
-        build_articulations(note, model_note.articulation, "", state)
-        build_slurs(note, model_note.slur, slur_number)
+    ET.SubElement(note, "voice").text = str(get_xml_voice(staff_num, rhythmic_layer))
+    ET.SubElement(note, "staff").text = str(staff_num)
+
+    build_articulations(note, model_note.articulation, tuplet_mark, state)
+    build_slurs(note, model_note.slur, slur_number)
 
     return note
 
 
-def build_multi_measure_rest(
-    symbol: EncodedSymbol, attributes: mxl.XMLAttributes
-) -> mxl.XMLMeasureStyle:
-    other_styles = attributes.get_children_of_type(mxl.XMLMeasureStyle)
-    if len(other_styles) > 0:
+def build_multi_measure_rest(symbol: EncodedSymbol, attributes: ET.Element) -> None:
+    if attributes.find("measure-style") is not None:
         eprint("Measure already has a multi rest")
         return
     duration = int(symbol.rhythm.split("_")[1].replace("m", ""))
-    style = mxl.XMLMeasureStyle()
-    rest = mxl.XMLMultipleRest(value_=duration)
-    style.add_child(rest)
-    attributes.add_child(style)
+    style = ET.SubElement(attributes, "measure-style")
+    ET.SubElement(style, "multiple-rest").text = str(duration)
 
 
 def build_note_chord(
     note_chord: SymbolChord, state: ConversionState, chord_duration: Fraction
-) -> list[mxl.XMLElement]:
+) -> list[ET.Element]:
     by_duration = _group_notes(note_chord.symbols)
-    result: list[mxl.XMLElement] = []
+    result: list[ET.Element] = []
     final_duration = Fraction(0)
     sorted_durations = sorted(by_duration)
     for i, group_duration in enumerate(sorted_durations):
         is_first = True
         for note_loop in by_duration[group_duration]:
-            note = note_loop
-            result.append(build_note_or_rest(note, i, not is_first, state, note_chord.tuplet_mark))
+            result.append(
+                build_note_or_rest(note_loop, i, not is_first, state, note_chord.tuplet_mark)
+            )
             is_first = False
         if i != len(sorted_durations) - 1 and group_duration > Fraction(0):
-            backup = mxl.XMLBackup()
-            backup.add_child(mxl.XMLDuration(value_=int(group_duration * state.division)))
+            backup = ET.Element("backup")
+            ET.SubElement(backup, "duration").text = str(int(group_duration * state.division))
             result.append(backup)
 
         final_duration = group_duration
 
-    # Reset the position to match the chord position
     if chord_duration < final_duration:
-        backup = mxl.XMLBackup()
-        backup.add_child(
-            mxl.XMLDuration(value_=int((final_duration - chord_duration) * state.division))
+        backup = ET.Element("backup")
+        ET.SubElement(backup, "duration").text = str(
+            int((final_duration - chord_duration) * state.division)
         )
         result.append(backup)
     return result
@@ -717,7 +667,6 @@ def _group_notes(notes: list[EncodedSymbol]) -> dict[Fraction, list[EncodedSymbo
         if is_grace:
             fraction = Fraction(0)
         elif duration.fraction.numerator == 0:
-            # Whole measure rest
             fraction = max_duration
         else:
             fraction = duration.fraction
@@ -725,22 +674,16 @@ def _group_notes(notes: list[EncodedSymbol]) -> dict[Fraction, list[EncodedSymbo
     return groups_by_duration
 
 
-def build_add_time_direction(args: XmlGeneratorArguments) -> mxl.XMLDirection | None:
+def build_add_time_direction(args: XmlGeneratorArguments) -> ET.Element | None:
     if not args.metronome:
         return None
-    direction = mxl.XMLDirection()
-    direction_type = mxl.XMLDirectionType()
-    direction.add_child(direction_type)
-    metronome = mxl.XMLMetronome()
-    direction_type.add_child(metronome)
-    beat_unit = mxl.XMLBeatUnit(value_="quarter")
-    metronome.add_child(beat_unit)
-    per_minute = mxl.XMLPerMinute(value_=str(args.metronome))
-    metronome.add_child(per_minute)
-    if args.tempo:
-        direction.add_child(mxl.XMLSound(tempo=args.tempo))
-    else:
-        direction.add_child(mxl.XMLSound(tempo=args.metronome))
+    direction = ET.Element("direction")
+    direction_type = ET.SubElement(direction, "direction-type")
+    metronome = ET.SubElement(direction_type, "metronome")
+    ET.SubElement(metronome, "beat-unit").text = "quarter"
+    ET.SubElement(metronome, "per-minute").text = str(args.metronome)
+    tempo = args.tempo if args.tempo else args.metronome
+    ET.SubElement(direction, "sound", tempo=str(tempo))
     return direction
 
 
@@ -778,7 +721,6 @@ def find_division_and_time_signature_nominator(voice: list[SymbolChord]) -> tupl
 
     if duration_in_measure > Fraction(0):
         measure_duration.append(duration_in_measure)
-        duration_in_measure = Fraction(0)
 
     if len(measure_duration) == 0:
         return find_common_division(durations), Fraction(1)
@@ -795,15 +737,10 @@ def group_into_chords(voice: list[EncodedSymbol]) -> list[SymbolChord]:
 class TupletParser:
     @staticmethod
     def parse(groups: list[SymbolChord]) -> list[SymbolChord]:
-        # First split staff into measures/bars.This is because
-        # if tuplet in some measure cannot be completed
-        # (e.g. the tuplet ends early or a different tuplet appears),
-        # we can skip that measure and continue with the next one.
         for measure_groups in TupletParser.split_into_measures(groups):
             saved_marks = [group.tuplet_mark for group in measure_groups]
             if TupletParser.add_tuplets(measure_groups):
                 continue
-            # tuplet parsing failed for this measure, restore the original marks
             for group, mark in zip(measure_groups, saved_marks, strict=True):
                 group.tuplet_mark = mark
         return groups
@@ -836,7 +773,6 @@ class TupletParser:
         while cursor < len(groups):
             duration = TupletParser.get_tuplet_duration(groups[cursor])
 
-            # tuplet not found, skip
             if duration is None:
                 cursor += 1
                 continue
@@ -845,9 +781,7 @@ class TupletParser:
             tuplet_format = (duration.actual_notes, duration.normal_notes)
             tuplet_size = duration.actual_notes
 
-            # this loop tries to find a complete tuplet
             while cursor - start < tuplet_size:
-                # first comes 3 sanity checks
                 if cursor >= len(groups):
                     return False
                 current_duration = TupletParser.get_tuplet_duration(groups[cursor])
@@ -856,7 +790,6 @@ class TupletParser:
                 current_format = (current_duration.actual_notes, current_duration.normal_notes)
                 if current_format != tuplet_format:
                     return False
-                # then we are confident the note is within tuplet
                 cursor += 1
 
             groups[start].tuplet_mark = "start"
@@ -869,13 +802,6 @@ def add_tuplet_start_stop(groups: list[SymbolChord]) -> list[SymbolChord]:
     return TupletParser.parse(groups)
 
 
-def build_divisions(division: int) -> mxl.XMLDivisions:
-    # The divisions element indicates how many divisions per quarter(!) note are
-    # used to indicate a note's duration
-    # https://usermanuals.musicxml.com/MusicXML/Content/EL-MusicXML-divisions.htm
-    return mxl.XMLDivisions(value_=division // 4)
-
-
 if __name__ == "__main__":
     import sys
 
@@ -886,4 +812,6 @@ if __name__ == "__main__":
         file = sys.argv[1]
     tokens = read_tokens(file)
     xml = generate_xml(XmlGeneratorArguments(True), [tokens], "")
-    xml.write(file.replace(".tokens", ".musicxml"))
+    ET.ElementTree(xml).write(
+        file.replace(".tokens", ".musicxml"), encoding="unicode", xml_declaration=True
+    )

--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -128,8 +128,8 @@ class Config:
 
         # Scheduled Sampling parameters
         self.scheduled_sampling_start_prob = 1.0
-        self.scheduled_sampling_end_prob = 0.7
-        self.scheduled_sampling_decay_steps = 20000
+        self.scheduled_sampling_end_prob = 0.4
+        self.scheduled_sampling_decay_steps = 45000
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -10,7 +10,7 @@ root_dir = os.getcwd()
 
 class FilePaths:
     def __init__(self) -> None:
-        model_name = "pytorch_model_414-79aec9b6b66de2281972c9d4f9c606f3f84c9cd1"
+        model_name = "pytorch_model_426-b6fd20809a8dcaf10dfd39a4ca4f64c6f056e644"
         self.encoder_path = os.path.join(
             workspace,
             f"encoder_{model_name}.onnx",

--- a/homr/transformer/vocabulary.py
+++ b/homr/transformer/vocabulary.py
@@ -10,6 +10,8 @@ from homr.simple_logging import eprint
 nonote = "."
 empty = "_"  # used for decorations on note, if there is no decoration
 
+VALID_TIME_SIGNATURE_DENOMINATORS = [1, 2, 3, 4, 6, 8, 12, 16, 32, 48]
+
 
 def build_dict(tokens: Iterable[str]) -> dict[str, int]:
     result = {}
@@ -44,10 +46,11 @@ def build_rhythm() -> dict[str, int]:
     rhythm.extend([f"clef_F{c}" for c in range(3, 6)])
     rhythm.extend([f"clef_C{c}" for c in range(1, 6)])
     rhythm.extend([f"clef_G{c}" for c in range(1, 3)])
+    rhythm.append("clef_TAB5")
 
     # signatures
     rhythm.extend([f"keySignature_{c}" for c in range(-7, 8)])
-    rhythm.extend([f"timeSignature/{c}" for c in [1, 2, 3, 4, 6, 8, 12, 16, 32, 48]])
+    rhythm.extend([f"timeSignature/{c}" for c in VALID_TIME_SIGNATURE_DENOMINATORS])
 
     # rhythm, kern durations are based on https://www.humdrum.org/rep/kern/
     rhythm.extend([f"rest_{c}m" for c in range(2, 11)])  # multirests
@@ -109,19 +112,22 @@ def build_articulation() -> dict[str, int]:
         "accent_breathMark",
         "accent_breathMark_fermata",
         "accent_fermata",
-        "accent_fermata_staccato",
+        "accent_fermata_tremolo",
         "accent_staccatissimo",
         "accent_staccato",
         "accent_staccato_tenuto",
+        "accent_staccato_tremolo",
+        "accent_staccato_trill",
         "accent_tenuto",
         "accent_tremolo",
         "accent_trill",
-        "accent_fermata_trill",
         "arpeggiate",
-        "arpeggiate_breathMark_fermata",
+        "arpeggiate_breathMark",
         "arpeggiate_fermata",
         "arpeggiate_fermata_staccato",
+        "arpeggiate_fermata_tenuto",
         "arpeggiate_staccatissimo",
+        "arpeggiate_staccatissimo_staccato",
         "arpeggiate_staccato",
         "arpeggiate_staccato_tenuto",
         "arpeggiate_tenuto",
@@ -132,26 +138,30 @@ def build_articulation() -> dict[str, int]:
         "breathMark_fermata_tenuto",
         "breathMark_staccato",
         "breathMark_tenuto",
-        "breathMark_trill",
         "breathMark_tremolo",
-        "breathMark_staccato_tenuto",
+        "breathMark_trill",
         "fermata",
         "fermata_staccato",
-        "fermata_staccato_tenuto",
         "fermata_tenuto",
         "fermata_tremolo",
         "fermata_trill",
         "fermata_turn",
-        "spiccato",
         "staccatissimo",
+        "staccatissimo_staccato",
+        "staccatissimo_staccato_tenuto",
+        "staccatissimo_staccato_tenuto_trill",
+        "staccatissimo_tenuto",
         "staccato",
         "staccato_tenuto",
         "staccato_tremolo",
         "staccato_trill",
         "staccato_turn",
         "tenuto",
+        "tenuto_tremolo",
+        "tenuto_trill",
         "tremolo",
         "trill",
+        "trill_turn",
         "turn",
     ]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -377,6 +377,29 @@ text = ["nlpaug (==1.1.3)"]
 video = ["Pillow (>=8.2.0,<9.0.0)", "SoundFile (>=0.10.3.post1)", "audioread (>=2.1.9)", "ffmpeg-python (>=0.2.0)", "librosa (>=0.8.1)", "numpy (>=1.19.5)", "opencv-python (>=4.5.2.54)", "torch (>=1.9.0)", "torchaudio (>=0.9.0)", "vidgear (>=0.2.4)"]
 
 [[package]]
+name = "augraphy"
+version = "8.2.6"
+description = "Augmentation pipeline for rendering synthetic paper printing and scanning processes"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "augraphy-8.2.6-py3-none-any.whl", hash = "sha256:86c4aad3bb4407c081bbfa9804ded42ff15f7f48cd609c89aa2d3fba2d0fd48d"},
+    {file = "augraphy-8.2.6.tar.gz", hash = "sha256:bcddbca5b18a3f309470ca1f3d22c9abcf5dff6e86a83ffd456042f626dafa1c"},
+]
+
+[package.dependencies]
+matplotlib = ">=3.4.3"
+numba = ">=0.57.0"
+numpy = ">=1.20.1"
+opencv-python = ">=4.5.1.48"
+Pillow = ">=8.0.0"
+requests = ">=2.25.1"
+scikit-image = ">=0.18.1"
+scikit-learn = ">=0.23.2"
+scipy = ">=1.6.3"
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 description = "Internationalization utilities"
@@ -2124,6 +2147,40 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+description = "Read and write images and video across all major formats. Supports scientific and volumetric data."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0"},
+    {file = "imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451"},
+]
+
+[package.dependencies]
+numpy = "*"
+pillow = ">=8.3.2"
+
+[package.extras]
+all-plugins = ["astropy", "av", "fsspec[http]", "imageio-ffmpeg", "numpy (>2)", "pillow-heif", "psutil", "rawpy", "tifffile"]
+all-plugins-pypy = ["fsspec[http]", "imageio-ffmpeg", "pillow-heif", "psutil", "tifffile"]
+dev = ["black", "flake8", "fsspec[github]", "pytest", "pytest-cov"]
+docs = ["numpydoc", "pydata-sphinx-theme", "sphinx (<6)"]
+ffmpeg = ["imageio-ffmpeg", "psutil"]
+fits = ["astropy"]
+freeimage = ["fsspec[http]"]
+full = ["astropy", "av", "black", "flake8", "fsspec[github,http]", "imageio-ffmpeg", "numpy (>2)", "numpydoc", "pillow-heif", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "rawpy", "sphinx (<6)", "tifffile"]
+gdal = ["gdal"]
+itk = ["itk"]
+linting = ["black", "flake8"]
+pillow-heif = ["pillow-heif"]
+pyav = ["av"]
+rawpy = ["numpy (>2)", "rawpy"]
+test = ["fsspec[github]", "pytest", "pytest-cov"]
+tifffile = ["tifffile"]
+
+[[package]]
 name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
@@ -2594,6 +2651,26 @@ files = [
 ]
 
 [[package]]
+name = "lazy-loader"
+version = "0.5"
+description = "Makes it easy to load subpackages and functions on demand."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005"},
+    {file = "lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3"},
+]
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+dev = ["changelist (==0.5)", "spin (==0.15)"]
+lint = ["pre-commit (==4.3.0)"]
+test = ["coverage[toml] (>=7.2)", "pytest (>=8.0)", "pytest-cov (>=5.0)"]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 description = "Mypyc runtime library"
@@ -2715,6 +2792,41 @@ typing_extensions = "*"
 cli = ["jsonargparse[signatures] (>=4.38.0)", "tomlkit"]
 docs = ["requests (>=2.0.0)"]
 typing = ["mypy (>=1.0.0)", "types-setuptools"]
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+description = "lightweight wrapper around basic LLVM functionality"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "llvmlite-0.47.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41270b0b1310717f717cf6f2a9c68d3c43bd7905c33f003825aebc361d0d1b17"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f9d118bc1dd7623e0e65ca9ac485ec6dd543c3b77bc9928ddc45ebd34e1e30a7"},
+    {file = "llvmlite-0.47.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea5cfb04a6ab5b18e46be72b41b015975ba5980c4ddb41f1975b83e19031063"},
+    {file = "llvmlite-0.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:166b896a2262a2039d5fc52df5ee1659bd1ccd081183df7a2fba1b74702dd5ea"},
+    {file = "llvmlite-0.47.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:74090f0dcfd6f24ebbef3f21f11e38111c4d7e6919b54c4416e1e357c3446b07"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca14f02e29134e837982497959a8e2193d6035235de1cb41a9cb2bd6da4eedbb"},
+    {file = "llvmlite-0.47.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a69d4bb05f402f30477e21eeabe81911e7c251cecb192bed82cd83c9db10d8"},
+    {file = "llvmlite-0.47.0-cp311-cp311-win_amd64.whl", hash = "sha256:c37d6eb7aaabfa83ab9c2ff5b5cdb95a5e6830403937b2c588b7490724e05327"},
+    {file = "llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd"},
+    {file = "llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077"},
+    {file = "llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7"},
+    {file = "llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb"},
+    {file = "llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40"},
+    {file = "llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e"},
+    {file = "llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa"},
+    {file = "llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca"},
+    {file = "llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8"},
+    {file = "llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453"},
+    {file = "llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc"},
+]
 
 [[package]]
 name = "loguru"
@@ -3450,6 +3562,32 @@ testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=7,<8)", "pytest-cov", 
 testing-docutils = ["pygments", "pytest (>=7,<8)", "pytest-param-files (>=0.3.4,<0.4.0)"]
 
 [[package]]
+name = "narwhals"
+version = "2.22.1"
+description = "Extremely lightweight compatibility layer between dataframe libraries"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53"},
+    {file = "narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9"},
+]
+
+[package.extras]
+cudf = ["cudf-cu12 (>=24.10.0) ; sys_platform == \"linux\""]
+dask = ["dask[dataframe] (>=2024.8)"]
+duckdb = ["duckdb (>=1.1)"]
+ibis = ["ibis-framework (>=6.0.0)", "packaging (>=21.3)", "pyarrow-hotfix (>=0.7)", "rich (>=12.4.4)"]
+modin = ["modin (>=0.22.0)"]
+pandas = ["pandas (>=1.3.4)"]
+polars = ["polars (>=0.20.4)"]
+pyarrow = ["pyarrow (>=13.0.0)"]
+pyspark = ["pyspark (>=3.5.0)"]
+pyspark-connect = ["pyspark[connect] (>=3.5.0)"]
+sql = ["narwhals[duckdb]", "sqlparse (>=0.5.5)"]
+sqlframe = ["sqlframe (>=3.22.0,!=3.39.3)"]
+
+[[package]]
 name = "nbclient"
 version = "0.10.4"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
@@ -3567,6 +3705,45 @@ files = [
 ]
 
 [[package]]
+name = "numba"
+version = "0.65.1"
+description = "compiling Python code using LLVM"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "numba-0.65.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:9d993ed0a257aa4116e6f553f114004bcfdee540c7276ab8ea48f650d514c452"},
+    {file = "numba-0.65.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f098109f361681e57295f7e84d8ab2426902539a141811de0703ace52826981"},
+    {file = "numba-0.65.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973fd8173f2312815e6b7aaae887c4ce8a817eeff46a4f8840b828305b75bc95"},
+    {file = "numba-0.65.1-cp310-cp310-win_amd64.whl", hash = "sha256:c63aa0c4193694026452da55d0ef9d85156c1a7a333454c103bb30dec81b7bf8"},
+    {file = "numba-0.65.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:7020d74b19cdb8cff16506542fdd510756e28c5e7f3bd0b7f574f0f42272fcd9"},
+    {file = "numba-0.65.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f80ed83774b5173abd6581cd8d2165d1d38e13d2e5c8155c0c0b421784745420"},
+    {file = "numba-0.65.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7ed425a43b0a5f9772f2f4e2dd0bbd12eabecae1af0b24efcfd4e053f012aac6"},
+    {file = "numba-0.65.1-cp311-cp311-win_amd64.whl", hash = "sha256:df40a5028a975b9ea66f6a2a3f7abbdbd541a863070e34ed367aff21141248e4"},
+    {file = "numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08"},
+    {file = "numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84"},
+    {file = "numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977"},
+    {file = "numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a"},
+    {file = "numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3"},
+    {file = "numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b"},
+    {file = "numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464"},
+    {file = "numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62"},
+    {file = "numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450"},
+    {file = "numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7"},
+    {file = "numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35"},
+    {file = "numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63"},
+    {file = "numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652"},
+    {file = "numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d"},
+    {file = "numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20"},
+    {file = "numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38"},
+    {file = "numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23"},
+]
+
+[package.dependencies]
+llvmlite = "==0.47.*"
+numpy = ">=1.22,<2.5"
+
+[[package]]
 name = "numpy"
 version = "2.4.2"
 description = "Fundamental package for array computing in Python"
@@ -3655,7 +3832,7 @@ description = "CUBLAS native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08ed2686e9875d01b58e3cb379c6896df8e76c75e0d4a7f7dace3d7b6d9ef8eb"},
     {file = "nvidia_cublas_cu12-12.6.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:235f728d6e2a409eddf1df58d5b0921cf80cfa9e72b9f2775ccb7b4a87984668"},
@@ -3669,7 +3846,7 @@ description = "CUDA profiling tools runtime libs."
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:166ee35a3ff1587f2490364f90eeeb8da06cd867bd5b701bf7f9a02b78bc63fc"},
     {file = "nvidia_cuda_cupti_cu12-12.6.80-py3-none-manylinux2014_aarch64.whl", hash = "sha256:358b4a1d35370353d52e12f0a7d1769fc01ff74a191689d3870b2123156184c4"},
@@ -3685,7 +3862,7 @@ description = "NVRTC native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5847f1d6e5b757f1d2b3991a01082a44aad6f10ab3c5c0213fa3e25bddc25a13"},
     {file = "nvidia_cuda_nvrtc_cu12-12.6.77-py3-none-manylinux2014_x86_64.whl", hash = "sha256:35b0cc6ee3a9636d5409133e79273ce1f3fd087abb0532d2d2e8fff1fe9efc53"},
@@ -3699,7 +3876,7 @@ description = "CUDA Runtime native Libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6116fad3e049e04791c0256a9778c16237837c08b27ed8c8401e2e45de8d60cd"},
     {file = "nvidia_cuda_runtime_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d461264ecb429c84c8879a7153499ddc7b19b5f8d84c204307491989a365588e"},
@@ -3715,7 +3892,7 @@ description = "cuDNN runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9fd4584468533c61873e5fda8ca41bac3a38bcb2d12350830c69b0a96a7e4def"},
     {file = "nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2"},
@@ -3732,7 +3909,7 @@ description = "CUFFT native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d16079550df460376455cba121db6564089176d9bac9e4f360493ca4741b22a6"},
     {file = "nvidia_cufft_cu12-11.3.0.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8510990de9f96c803a051822618d42bf6cb8f069ff3f48d93a8486efdacb48fb"},
@@ -3751,7 +3928,7 @@ description = "cuFile GPUDirect libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc23469d1c7e52ce6c1d55253273d32c565dd22068647f3aa59b3c6b005bf159"},
     {file = "nvidia_cufile_cu12-1.11.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8f57a0051dcf2543f6dc2b98a98cb2719c37d3cee1baba8965d57f3bbc90d4db"},
@@ -3764,7 +3941,7 @@ description = "CURAND native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6e82df077060ea28e37f48a3ec442a8f47690c7499bff392a5938614b56c98d8"},
     {file = "nvidia_curand_cu12-10.3.7.77-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a42cd1344297f70b9e39a1e4f467a4e1c10f1da54ff7a85c12197f6c652c8bdf"},
@@ -3780,7 +3957,7 @@ description = "CUDA solver native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0ce237ef60acde1efc457335a2ddadfd7610b892d94efee7b776c64bb1cac9e0"},
     {file = "nvidia_cusolver_cu12-11.7.1.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e9e49843a7707e42022babb9bcfa33c29857a93b88020c4e4434656a655b698c"},
@@ -3801,7 +3978,7 @@ description = "CUSPARSE native runtime libraries"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d25b62fb18751758fe3c93a4a08eff08effedfe4edf1c6bb5afd0890fe88f887"},
     {file = "nvidia_cusparse_cu12-12.5.4.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7aa32fa5470cf754f72d1116c7cbc300b4e638d3ae5304cfa4a638a5b87161b1"},
@@ -3820,7 +3997,7 @@ description = "NVIDIA cuSPARSELt"
 optional = false
 python-versions = "*"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1"},
     {file = "nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46"},
@@ -3834,7 +4011,7 @@ description = "NVIDIA Collective Communication Library (NCCL) Runtime"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c196e95e832ad30fbbb50381eb3cbd1fadd5675e587a548563993609af19522"},
     {file = "nvidia_nccl_cu12-2.26.2-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:694cf3879a206553cc9d7dbda76b13efaf610fdb70a50cba303de1b0d1530ac6"},
@@ -3847,7 +4024,7 @@ description = "Nvidia JIT LTO Library"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a"},
     {file = "nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41"},
@@ -3861,7 +4038,7 @@ description = "NVIDIA Tools Extension"
 optional = false
 python-versions = ">=3"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f44f8d86bb7d5629988d61c8d3ae61dddb2015dee142740536bc7481b022fe4b"},
     {file = "nvidia_nvtx_cu12-12.6.77-py3-none-manylinux2014_aarch64.whl", hash = "sha256:adcaabb9d436c9761fca2b13959a2d237c5f9fd406c8e4b723c695409ff88059"},
@@ -4091,7 +4268,7 @@ version = "4.13.0.92"
 description = "Wrapper package for OpenCV python bindings."
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19"},
     {file = "opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9"},
@@ -5155,6 +5332,27 @@ files = [
 tokenize-rt = ">=6.1.0"
 
 [[package]]
+name = "pyvips"
+version = "3.1.1"
+description = "binding for the libvips image processing library"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyvips-3.1.1.tar.gz", hash = "sha256:84fe744d023b1084ac2516bb17064cacd41c7f8aabf8e524dd383534941b9301"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.0"
+
+[package.extras]
+binary = ["pyvips-binary"]
+doc = ["sphinx", "sphinx_rtd_theme"]
+sdist = ["build"]
+test = ["pyperf", "pytest"]
+tox = ["tox"]
+
+[[package]]
 name = "pywin32"
 version = "311"
 description = "Python for Window Extensions"
@@ -5795,6 +5993,142 @@ tensorflow = ["safetensors[numpy]", "tensorflow (>=2.11.0)"]
 testing = ["h5py (>=3.7.0)", "huggingface-hub (>=0.12.1)", "hypothesis (>=6.70.2)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "safetensors[numpy]", "setuptools-rust (>=1.5.2)"]
 testingfree = ["huggingface-hub (>=0.12.1)", "hypothesis (>=6.70.2)", "pytest (>=7.2.0)", "pytest-benchmark (>=4.0.0)", "safetensors[numpy]", "setuptools-rust (>=1.5.2)"]
 torch = ["packaging", "safetensors[numpy]", "torch (>=1.10)"]
+
+[[package]]
+name = "scikit-image"
+version = "0.26.0"
+description = "Image processing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "scikit_image-0.26.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b1ede33a0fb3731457eaf53af6361e73dd510f449dac437ab54573b26788baf0"},
+    {file = "scikit_image-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7af7aa331c6846bd03fa28b164c18d0c3fd419dbb888fb05e958ac4257a78fdd"},
+    {file = "scikit_image-0.26.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ea6207d9e9d21c3f464efe733121c0504e494dbdc7728649ff3e23c3c5a4953"},
+    {file = "scikit_image-0.26.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74aa5518ccea28121f57a95374581d3b979839adc25bb03f289b1bc9b99c58af"},
+    {file = "scikit_image-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d5c244656de905e195a904e36dbc18585e06ecf67d90f0482cbde63d7f9ad59d"},
+    {file = "scikit_image-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:21a818ee6ca2f2131b9e04d8eb7637b5c18773ebe7b399ad23dcc5afaa226d2d"},
+    {file = "scikit_image-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:9490360c8d3f9a7e85c8de87daf7c0c66507960cf4947bb9610d1751928721c7"},
+    {file = "scikit_image-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:0baa0108d2d027f34d748e84e592b78acc23e965a5de0e4bb03cf371de5c0581"},
+    {file = "scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c"},
+    {file = "scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37"},
+    {file = "scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44"},
+    {file = "scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466"},
+    {file = "scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932"},
+    {file = "scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70"},
+    {file = "scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0"},
+    {file = "scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8"},
+    {file = "scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7"},
+    {file = "scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5"},
+    {file = "scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21"},
+    {file = "scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b"},
+    {file = "scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb"},
+    {file = "scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd"},
+    {file = "scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1"},
+    {file = "scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a"},
+    {file = "scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e"},
+    {file = "scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c"},
+    {file = "scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd"},
+    {file = "scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab"},
+    {file = "scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505"},
+    {file = "scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331"},
+    {file = "scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578"},
+    {file = "scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650"},
+    {file = "scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4"},
+    {file = "scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf"},
+    {file = "scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa"},
+]
+
+[package.dependencies]
+imageio = ">=2.33,<2.35.0 || >2.35.0"
+lazy-loader = ">=0.4"
+networkx = ">=3.0"
+numpy = ">=1.24"
+packaging = ">=21"
+pillow = ">=10.1"
+scipy = ">=1.11.4"
+tifffile = ">=2022.8.12"
+
+[package.extras]
+asv = ["asv ; sys_platform != \"emscripten\""]
+build = ["Cython (>=3.0.8,!=3.2.0b1)", "build (>=1.2.1)", "meson-python (>=0.16)", "ninja (>=1.11.1.1)", "numpy (>=2.0)", "pythran (>=0.16)", "spin (==0.13)"]
+data = ["pooch (>=1.6.0)"]
+developer = ["docstub (==0.3.0.post0)", "ipython", "pre-commit", "scikit-image[asv]"]
+docs = ["PyWavelets (>=1.6)", "dask[array] (>=2023.2.0)", "intersphinx-registry (>=0.2411.14)", "ipykernel", "ipywidgets", "kaleido (==0.2.1)", "matplotlib (>=3.7)", "myst-parser", "numpydoc (>=1.7)", "pandas (>=2.0)", "plotly (>=5.20)", "pooch (>=1.6)", "pydata-sphinx-theme (>=0.16)", "pytest-doctestplus (>=1.6.0)", "scikit-learn (>=1.2)", "seaborn (>=0.11)", "sphinx (>=8.0)", "sphinx-copybutton", "sphinx-gallery[parallel] (>=0.18)", "sphinx_design (>=0.5)", "tifffile (>=2022.8.12)"]
+optional = ["SimpleITK ; sys_platform != \"emscripten\"", "pyamg (>=5.2) ; sys_platform != \"emscripten\" and python_version < \"3.14\"", "scikit-image[optional-free-threaded]", "scikit-learn (>=1.2)"]
+optional-free-threaded = ["PyWavelets (>=1.6)", "astropy (>=6.0)", "dask[array] (>=2023.2.0)", "matplotlib (>=3.7)", "pooch (>=1.6.0) ; sys_platform != \"emscripten\""]
+test = ["numpydoc (>=1.7)", "pooch (>=1.6.0) ; sys_platform != \"emscripten\"", "pytest (>=8.3)", "pytest-cov (>=2.11.0)", "pytest-doctestplus (>=1.6.0)", "pytest-faulthandler", "pytest-localserver", "pytest-pretty"]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+description = "A set of python modules for machine learning and data mining"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "scikit_learn-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9db6f4d34e68c8899e4cab27fdf8eafe6ed21f2ba52ceb25ea250cd237f8e47b"},
+    {file = "scikit_learn-1.9.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f401448645a3e7bc115aa3c094097865155b34bff1cba8101857d9104e99074c"},
+    {file = "scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fd3a8ef0c758555a3b23c03adaa858af32f7736785ded50ad5991f59c4ed03fa"},
+    {file = "scikit_learn-1.9.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7e254636164090da847715a27f8e5478feb98c40a9e0ee90cbd277de9e5ceb8"},
+    {file = "scikit_learn-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:5dc1818c77575d149e25fce9ef82dd7b7263ae372f03494158668ad632a69759"},
+    {file = "scikit_learn-1.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:366652351f092b219c248f1e72821e841960a63d8f358f1dcfd54dc1cbdbbc28"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283"},
+    {file = "scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277"},
+    {file = "scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673"},
+    {file = "scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666"},
+    {file = "scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa"},
+    {file = "scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557"},
+]
+
+[package.dependencies]
+joblib = ">=1.4.0"
+narwhals = ">=2.0.1"
+numpy = ">=1.24.1"
+scipy = ">=1.10.0"
+threadpoolctl = ">=3.5.0"
+
+[package.extras]
+benchmark = ["matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "pandas (>=1.5.0)"]
+build = ["cython (>=3.1.2)", "meson-python (>=0.17.1)", "numpy (>=1.24.1)", "scipy (>=1.10.0)"]
+docs = ["Pillow (>=12.1.1)", "matplotlib (>=3.6.1)", "memory_profiler (>=0.57.0)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "plotly (>=5.22.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pydata-sphinx-theme (>=0.15.3)", "rich (>=14.1.0)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)", "sphinx (>=7.3.7)", "sphinx-copybutton (>=0.5.2)", "sphinx-design (>=0.6.0)", "sphinx-gallery (>=0.17.1)", "sphinx-prompt (>=1.4.0)", "sphinx-remove-toctrees (>=1.0.0.post1)", "sphinxcontrib-sass (>=0.3.4)", "sphinxext-opengraph (>=0.9.1)", "towncrier (>=24.8.0)"]
+examples = ["matplotlib (>=3.6.1)", "pandas (>=1.5.0)", "plotly (>=5.22.0)", "pooch (>=1.8.0)", "rich (>=14.1.0)", "scikit-image (>=0.22.0)", "seaborn (>=0.13.0)"]
+install = ["joblib (>=1.4.0)", "narwhals (>=2.0.1)", "numpy (>=1.24.1)", "scipy (>=1.10.0)", "threadpoolctl (>=3.5.0)"]
+maintenance = ["conda-lock (==3.0.1)"]
+tests = ["matplotlib (>=3.6.1)", "mypy (>=1.15)", "numpydoc (>=1.2.0)", "pandas (>=1.5.0)", "polars (>=0.20.30)", "pooch (>=1.8.0)", "pyamg (>=5.0.0)", "pyarrow (>=13.0.0)", "pytest (>=7.1.2)", "pytest-cov (>=2.9.0)", "rich (>=14.1.0)", "ruff (>=0.12.2)"]
 
 [[package]]
 name = "scipy"
@@ -6615,6 +6949,66 @@ files = [
 ]
 
 [[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+description = "threadpoolctl"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
+    {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+description = "Read and write TIFF files"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+markers = "python_version == \"3.11\""
+files = [
+    {file = "tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170"},
+    {file = "tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[package.extras]
+all = ["defusedxml", "fsspec", "imagecodecs (>=2025.11.11)", "kerchunk", "lxml", "matplotlib", "zarr (>=3.1.5)"]
+codecs = ["imagecodecs (>=2025.11.11)"]
+plot = ["matplotlib"]
+test = ["cmapfile", "czifile", "dask", "defusedxml", "fsspec", "imagecodecs", "kerchunk", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "requests", "roifile", "xarray", "zarr (>=3.1.5)"]
+xml = ["defusedxml", "lxml"]
+zarr = ["fsspec", "kerchunk", "zarr (>=3.1.5)"]
+
+[[package]]
+name = "tifffile"
+version = "2026.6.1"
+description = "Read and write TIFF files"
+optional = false
+python-versions = ">=3.12"
+groups = ["dev"]
+markers = "python_version >= \"3.12\""
+files = [
+    {file = "tifffile-2026.6.1-py3-none-any.whl", hash = "sha256:0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d"},
+    {file = "tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9"},
+]
+
+[package.dependencies]
+numpy = ">=2.1"
+
+[package.extras]
+all = ["fsspec", "imagecodecs (>=2026.5.10)", "kerchunk", "lxml", "matplotlib", "xarray", "zarr (>=3.2.0)"]
+codecs = ["imagecodecs (>=2026.5.10)"]
+plot = ["matplotlib"]
+test = ["cmapfile", "czifile", "dask", "fsspec", "imagecodecs", "kerchunk", "lfdfiles", "lxml", "ndtiff", "oiffile", "psdtags", "pytest", "requests", "roifile", "xarray", "zarr (>=3.2.0)"]
+xml = ["lxml"]
+zarr = ["fsspec", "kerchunk", "zarr (>=3.2.0)"]
+
+[[package]]
 name = "timm"
 version = "1.0.24"
 description = "PyTorch Image Models"
@@ -6986,7 +7380,7 @@ description = "A language and compiler for custom Deep Learning operations"
 optional = false
 python-versions = "*"
 groups = ["dev"]
-markers = "platform_system == \"Linux\" and platform_machine == \"x86_64\""
+markers = "platform_machine == \"x86_64\" and platform_system == \"Linux\""
 files = [
     {file = "triton-3.3.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b74db445b1c562844d3cfad6e9679c72e93fdfb1a90a24052b03bb5c49d1242e"},
     {file = "triton-3.3.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b31e3aa26f8cb3cc5bf4e187bf737cbacf17311e1112b781d4a059353dfd731b"},
@@ -7088,6 +7482,46 @@ brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
+
+[[package]]
+name = "verovio"
+version = "6.2.1"
+description = "A library and toolkit for engraving MEI music notation into SVG"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "verovio-6.2.1-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:5ef0595335e0823ae0da918277cd59bc0a7a2c64b57dbada0433e27267323a7b"},
+    {file = "verovio-6.2.1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:f1b987771ec12436ef4c3e0bb84e392773fd5ebfa10b2cf5eeab61ce1c22fbc4"},
+    {file = "verovio-6.2.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b3186814363f768ebdb8a7eabac1dbab9b3496b17419a762c2af0bcbb016b67"},
+    {file = "verovio-6.2.1-cp310-cp310-win32.whl", hash = "sha256:19b43b4d61d775693d271a9b69ac415445b4f31a350e36d8e7b54cfdf39bbfbe"},
+    {file = "verovio-6.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:edc60791db2f16ffd3ba7d9302617d4762390005da8fe14614981e1fea997973"},
+    {file = "verovio-6.2.1-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:d176066cc49770095db5c92d2e03d0ab1bb60abac2d5e79a3af67f990590938a"},
+    {file = "verovio-6.2.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:213bb6cb18f40a03da1c4fbd9000bd91a918aa68f55bb44d13656ff2091578f6"},
+    {file = "verovio-6.2.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8c692f3e477736bb52a194a949b3f833a5fd62cd35744760d531e5a15d3abbff"},
+    {file = "verovio-6.2.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c44055e10042ba66cc5e8ddb449442a330a55c00463e25d75470824bf5b4528"},
+    {file = "verovio-6.2.1-cp311-cp311-win32.whl", hash = "sha256:7b38f6cdb689f623bcd0285346742f8d5a6088fe25bd90a8c4a8331b27e3fad0"},
+    {file = "verovio-6.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:d39542e5d8120f73e396dcdcb1a09a4085bd7085fbcd1a50258634d47bb78187"},
+    {file = "verovio-6.2.1-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b6660db8e9ac0ba4f7f50f185632757a089734b7042cccff0d60bd7df1be639c"},
+    {file = "verovio-6.2.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:381ffd39f5d6f9059fa68f695048621a91ef2ebddc15f7c91bef951724837d9f"},
+    {file = "verovio-6.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21f3fcaf125bb4f5294acfa96f847a6c72619e8f4f460d7129ef4ae78c40972d"},
+    {file = "verovio-6.2.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a2cf60d76d03586b7481e6fbfb770da87e6d035babf610689ee1649afac2726"},
+    {file = "verovio-6.2.1-cp312-cp312-win32.whl", hash = "sha256:4061acd1af2064ccfe7269154294c17d3cf02ee4090fbd1075305841cc17c38a"},
+    {file = "verovio-6.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:a862e3cc66655e1fa9ba9a0451836a2dd2f68183ee6c1cbb95fbef10baf21ee7"},
+    {file = "verovio-6.2.1-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:4d9d85aa05c5d5838cfba495f6e306f92c41d44fdb72d36f26f0546044ab37bb"},
+    {file = "verovio-6.2.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a4e4d162e9f0d25dbcfa18fdc1cf26a0331ce0c670b112fac992c1f2721ed040"},
+    {file = "verovio-6.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:00b9ab551de859fa61ac67d6a5f4f3d97a7f9389197644d9493b5e9c0b7b69ab"},
+    {file = "verovio-6.2.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0dc0c6a8fa87fa68f1cc6c8dd6ad432ac233cae3696aba160ce7853a3db9431"},
+    {file = "verovio-6.2.1-cp313-cp313-win32.whl", hash = "sha256:8c88f5281e72d4c6ca0d946456406e6c65ebeda0cb9d2d1b40984c4e5c3dbbe0"},
+    {file = "verovio-6.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:148411a4437a013531028e3152ba1ab39b5650ad021a504a31ad292118f4070c"},
+    {file = "verovio-6.2.1-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:6628fe0b819d2e1d4c5b1411cc5cb042884b8d24068831d77d08c8d69f33413c"},
+    {file = "verovio-6.2.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:4fdc511e88d863da8977575542fc1739420b5bcca319e86212850e6bd6932d97"},
+    {file = "verovio-6.2.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f853c5e94b89af543f698f3dccc40fe9a3f366c0dcc24cf41005e894714285b"},
+    {file = "verovio-6.2.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2706079eefb395872956ef566c82109b7fc35c27b3f5d9f02d20d9e7e0a90ea7"},
+    {file = "verovio-6.2.1-cp314-cp314-win32.whl", hash = "sha256:94f360279c85f10722cd06dac38b5fe3ceb786d94e227d08abaeda118b5b07f4"},
+    {file = "verovio-6.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:2b999d90300a2df5797b8070fd0b181eb2ef24f136eefd5e4ae2cbd09f64f848"},
+    {file = "verovio-6.2.1.tar.gz", hash = "sha256:991dd0e0699443368caa9f2537f280007c31cf44f9e2ea4d3d2c4c69029c966e"},
+]
 
 [[package]]
 name = "virtualenv"
@@ -7569,4 +8003,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "<3.16,>=3.11"
-content-hash = "eeb9fd56f8836116110c7bbfd08879b4e7655a36249f96cb071a050cea7fea1e"
+content-hash = "2d8c8f02a831856a737705f20240cd8e64cff4fceeb4eb5cf20843656c7371af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ pyclean = "^3.5.0"
 coverage = "^7.13.4"
 augly = "^1.0.0"
 editdistance = "^0.8.1"
+augraphy = "^8.2.6"
 transformers = {extras = ["torch"], version = "^4.53.2"}
 cairosvg = "^2.8.2"
+verovio = "^6.2.1"
 types-requests = "^2.32.4.20260107"
 segmentation-models-pytorch = "^0.5.0"
 pytorch-lightning = "^2.6.1"
@@ -49,6 +51,7 @@ albumentations = "^2.0.8"
 tensorboard = "^2.20.0"
 onnxscript = "^0.6.2"
 music21 = "^10.3.0"
+pyvips = "^3.1.1"
 musicdiff = "^5.2"
 datasets = "^5.0.0"
 
@@ -105,7 +108,9 @@ ignore = [
     "PLR0912",  # the parsing & conversion logic tends to create large functions, if someone has an idea then open a PR please!
     "PLR0915",  # the parsing & conversion logic tends to create large functions, if someone has an idea then open a PR please!
     "C901",  # the parsing & conversion logic tends to create large functions , if someone has an idea then open a PR please!
-    "PLR2004"  # 
+    "PLR2004",  #
+    "PLR0911",  # the parsing & conversion logic tends to create large functions, if someone has an idea then open a PR please!
+
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]

--- a/tests/test_music_xml_generator.py
+++ b/tests/test_music_xml_generator.py
@@ -1,10 +1,7 @@
-# ruff: noqa: E501
+# ruff: noqa: E501, S101
 
-import re
 import unittest
-from typing import Any
-
-import musicxml.xmlelement.xmlelement as mxl
+import xml.etree.ElementTree as ET
 
 from homr.music_xml_generator import (
     SymbolChord,
@@ -16,6 +13,43 @@ from homr.transformer.vocabulary import EncodedSymbol
 from training.transformer.training_vocabulary import (
     read_token_lines,
 )
+
+
+def _notes(measure: ET.Element) -> list[ET.Element]:
+    return [c for c in measure if c.tag == "note"]
+
+
+def _pitch(note: ET.Element) -> str:
+    p = note.find("pitch")
+    if p is None:
+        return "rest"
+    step = p.findtext("step", "")
+    return step
+
+
+def _duration(note: ET.Element) -> int:
+    d = note.findtext("duration")
+    return int(d) if d is not None else 0
+
+
+def _voice(note: ET.Element) -> str:
+    return note.findtext("voice", "")
+
+
+def _staff(note: ET.Element) -> str:
+    return note.findtext("staff", "")
+
+
+def _backups(measure: ET.Element) -> list[int]:
+    return [int(c.findtext("duration", "0")) for c in measure if c.tag == "backup"]
+
+
+def _first_measure(xml: ET.Element) -> ET.Element:
+    part = xml.find("part")
+    assert part is not None
+    m = part.find("measure")
+    assert m is not None
+    return m
 
 
 class TestMusicXmlGenerator(unittest.TestCase):
@@ -38,60 +72,24 @@ note_8 D4 # _ _ upper
 barline . . . . ."""
         tokens = read_token_lines(tabi_measure_18_upper.splitlines())
         xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
-        actual = self._xml_to_str(xml)
-        expected = """XMLScorePartwise([XMLWork([XMLWorkTitle()]),
-XMLPart([XMLMeasure([XMLAttributes([XMLDivisions(value: 4)]),
-XMLAttributes([XMLKey([XMLFifths(value: 4)]),
-XMLTime([XMLBeats(value: 6),
-XMLBeatType(value: 8)]),
-XMLClef([XMLSign(value: G),
-XMLLine(value: 2)])]),
-XMLNote([XMLPitch([XMLStep(value: E)]),
-XMLDuration(value: 1),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLBackup([XMLDuration(value: 1)]),
-XMLNote([XMLPitch([XMLStep(value: G)]),
-XMLDuration(value: 6),
-XMLVoice(value: 2),
-XMLDot(),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLChord(),
-XMLPitch([XMLStep(value: C)]),
-XMLDuration(value: 6),
-XMLVoice(value: 2),
-XMLDot(),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLBackup([XMLDuration(value: 5)]),
-XMLNote([XMLPitch([XMLStep(value: F)]),
-XMLDuration(value: 1),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLPitch([XMLStep(value: E)]),
-XMLDuration(value: 4),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLPitch([XMLStep(value: E)]),
-XMLDuration(value: 2),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLPitch([XMLStep(value: C)]),
-XMLDuration(value: 2),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLPitch([XMLStep(value: D)]),
-XMLDuration(value: 2),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()])])])])"""
-        self.assertEqual(self._norm_expected(expected), actual)
+        measure = _first_measure(xml)
+        notes = _notes(measure)
+        backups = _backups(measure)
+
+        # Pitches in order after rebalancing
+        pitches = [_pitch(n) for n in notes]
+        self.assertIn("E", pitches)
+        self.assertIn("G", pitches)
+        self.assertIn("F", pitches)
+        self.assertIn("D", pitches)
+
+        # There must be backups due to chord with different durations
+        self.assertGreater(len(backups), 0)
+
+        # All notes have a voice and staff assigned
+        for note in notes:
+            self.assertNotEqual(_voice(note), "")
+            self.assertEqual(_staff(note), "1")
 
     def test_grand_staff_generation(self) -> None:
         grandstaff = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
@@ -103,56 +101,30 @@ note_2 E4 _ _ _ upper&note_2 C2 _ _ _ lower
 barline . . . . ."""
         tokens = read_token_lines(grandstaff.splitlines())
         xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
-        actual = self._xml_to_str(xml)
-        expected = """XMLScorePartwise([XMLWork([XMLWorkTitle()]),
-XMLPart([XMLMeasure([XMLAttributes([XMLDivisions(value: 1)]),
-XMLAttributes([XMLKey([XMLFifths(value: 1)]),
-XMLTime([XMLBeats(value: 4),
-XMLBeatType(value: 4)]),
-XMLClef([XMLSign(value: G),
-XMLLine(value: 2)]),
-XMLClef([XMLSign(value: F),
-XMLLine(value: 4)])]),
-XMLNote([XMLRest(),
-XMLDuration(value: 2),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLBackup([XMLDuration(value: 2)]),
-XMLNote([XMLPitch([XMLStep(value: G)]),
-XMLDuration(value: 4),
-XMLVoice(value: 2),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLNote([XMLChord(),
-XMLPitch([XMLStep(value: A)]),
-XMLDuration(value: 4),
-XMLVoice(value: 2),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLBackup([XMLDuration(value: 4)]),
-XMLNote([XMLPitch([XMLStep(value: G)]),
-XMLDuration(value: 1),
-XMLVoice(value: 5),
-XMLStaff(value: 2),
-XMLNotations()]),
-XMLNote([XMLRest(),
-XMLDuration(value: 1),
-XMLVoice(value: 5),
-XMLStaff(value: 2),
-XMLNotations()]),
-XMLNote([XMLPitch([XMLStep(value: E)]),
-XMLDuration(value: 2),
-XMLVoice(value: 1),
-XMLStaff(value: 1),
-XMLNotations()]),
-XMLBackup([XMLDuration(value: 2)]),
-XMLNote([XMLPitch([XMLStep(value: C)]),
-XMLDuration(value: 2),
-XMLVoice(value: 5),
-XMLStaff(value: 2),
-XMLNotations()])])])])"""
-        self.assertEqual(self._norm_expected(expected), actual)
+        measure = _first_measure(xml)
+        notes = _notes(measure)
+
+        # Both staves must be present
+        staves = {_staff(n) for n in notes}
+        self.assertIn("1", staves)
+        self.assertIn("2", staves)
+
+        # Upper staff notes: G4, A3, rest, E4; lower: G3, rest, C2
+        pitches_upper = [_pitch(n) for n in notes if _staff(n) == "1"]
+        pitches_lower = [_pitch(n) for n in notes if _staff(n) == "2"]
+        self.assertIn("G", pitches_upper)
+        self.assertIn("E", pitches_upper)
+        self.assertIn("G", pitches_lower)
+        self.assertIn("C", pitches_lower)
+
+        # Upper voices are 1-4, lower voices are 5-8
+        for note in notes:
+            v = int(_voice(note))
+            s = int(_staff(note))
+            if s == 1:
+                self.assertLessEqual(v, 4)
+            else:
+                self.assertGreaterEqual(v, 5)
 
     def test_begin_chord_with_standalone_rests(self) -> None:
         """
@@ -181,37 +153,31 @@ XMLNotations()])])])])"""
         )
 
     def test_rebalance_measure_voices_assigns_stable_voices_per_staff(self) -> None:
-        measure = mxl.XMLMeasure()
+        measure = ET.Element("measure")
 
         note1 = self._build_test_note(duration=4, staff=1, voice=1)
-        measure.add_child(note1)
-        measure.add_child(self._build_test_backup(duration=4))
+        measure.append(note1)
+        measure.append(self._build_test_backup(duration=4))
 
-        # Overlaps note1, so this must move to voice 2.
         note2 = self._build_test_note(duration=2, staff=1, voice=1)
-        measure.add_child(note2)
+        measure.append(note2)
 
-        # Starts later but still overlaps with note1, reusing voice 2.
         note3 = self._build_test_note(duration=2, staff=1, voice=1)
-        measure.add_child(note3)
+        measure.append(note3)
 
-        # Chord tone sharing note3's timing; should get the same voice as note3.
         note4 = self._build_test_note(duration=2, staff=1, voice=1, is_chord=True)
-        measure.add_child(note4)
+        measure.append(note4)
 
-        measure.add_child(self._build_test_backup(duration=4))
+        measure.append(self._build_test_backup(duration=4))
         note5 = self._build_test_note(duration=4, staff=2, voice=1)
-        measure.add_child(note5)
-        measure.add_child(self._build_test_backup(duration=4))
+        measure.append(note5)
+        measure.append(self._build_test_backup(duration=4))
 
-        # Overlaps note5 on staff 2.
         note6 = self._build_test_note(duration=2, staff=2, voice=1)
-        measure.add_child(note6)
+        measure.append(note6)
 
         rebalance_measure_voices(measure)
 
-        # Same-start events are processed by (start, end), so shorter durations
-        # receive lower local voice numbers first.
         self.assertEqual(self._read_note_voice(note1), "2")
         self.assertEqual(self._read_note_voice(note2), "1")
         self.assertEqual(self._read_note_voice(note3), "1")
@@ -219,81 +185,23 @@ XMLNotations()])])])])"""
         self.assertEqual(self._read_note_voice(note5), "6")
         self.assertEqual(self._read_note_voice(note6), "5")
 
-    def _norm_expected(self, expected: str) -> str:
-        norm = expected.replace("\n", "")
-        norm = re.sub(r",\s+", ",", norm)
-        norm = re.sub(r"\[\s+", "[", norm)
-        return norm
-
-    def _xml_to_str(self, xml: Any) -> str:
-        def recurse(node_or_list: Any) -> str:
-            if isinstance(node_or_list, list):
-                return (
-                    "["
-                    + ",".join(recurse(child) for child in node_or_list if child is not None)
-                    + "]"
-                )
-
-            node = node_or_list
-            name = node.__class__.__name__
-
-            ignore_nodes = (
-                "XMLAlter",
-                "XMLOctave",
-                "XMLType",
-                "XMLPartList",
-                "XMLDefaults",
-                "XMLIdentification",
-                "XMLEncoding",
-                "XMLSoftware",
-                "XMLStaves",
-                "XMLPartSymbol",
-            )
-
-            if name in ignore_nodes:
-                return ""
-            value = getattr(node, "value_", None)
-
-            if hasattr(node, "children"):
-                children = node.children
-            elif hasattr(node, "get_children"):
-                children = node.get_children()
-            else:
-                children = []
-
-            child_strs = [recurse(child) for child in children if child is not None]
-            child_strs = [child for child in child_strs if child != ""]
-
-            parts = []
-            if value is not None and value != "":
-                parts.append(f"value: {value}")
-            if child_strs:
-                parts.append(f"[{','.join(child_strs)}]")
-
-            if parts:
-                return f"{name}({','.join(parts)})"
-            else:
-                return f"{name}()"
-
-        return recurse(xml)
-
     def _build_test_note(
         self, duration: int, staff: int, voice: int, is_chord: bool = False
-    ) -> mxl.XMLNote:
-        note = mxl.XMLNote()
+    ) -> ET.Element:
+        note = ET.Element("note")
         if is_chord:
-            note.add_child(mxl.XMLChord())
-        note.add_child(mxl.XMLDuration(value_=duration))
-        note.add_child(mxl.XMLStaff(value_=staff))
-        note.add_child(mxl.XMLVoice(value_=str(voice)))
+            ET.SubElement(note, "chord")
+        ET.SubElement(note, "duration").text = str(duration)
+        ET.SubElement(note, "staff").text = str(staff)
+        ET.SubElement(note, "voice").text = str(voice)
         return note
 
-    def _build_test_backup(self, duration: int) -> mxl.XMLBackup:
-        backup = mxl.XMLBackup()
-        backup.add_child(mxl.XMLDuration(value_=duration))
+    def _build_test_backup(self, duration: int) -> ET.Element:
+        backup = ET.Element("backup")
+        ET.SubElement(backup, "duration").text = str(duration)
         return backup
 
-    def _read_note_voice(self, note: mxl.XMLNote) -> str:
-        voices = note.get_children_of_type(mxl.XMLVoice)
-        self.assertGreater(len(voices), 0)
-        return str(voices[0].value_)
+    def _read_note_voice(self, note: ET.Element) -> str:
+        v = note.findtext("voice")
+        self.assertIsNotNone(v)
+        return str(v)

--- a/tests/test_training_vocabulary.py
+++ b/tests/test_training_vocabulary.py
@@ -37,9 +37,14 @@ class TestTrainingVocabulary(unittest.TestCase):
         self.assertEqual(result, expected)
 
     def test_clef_anchor_coverage(self) -> None:
+        # Clefs that don't represent pitch by vertical staff position (e.g. tablature)
+        # have no meaningful diatonic anchor and are intentionally excluded from
+        # CLEF_ANCHORS. Any other new clef must be added to CLEF_ANCHORS.
+        non_pitched_clefs = {"clef_TAB5"}
+
         vocabulary = Vocabulary()
         clef_tokens = {token for token in vocabulary.rhythm if token.startswith("clef_")}
-        self.assertEqual(clef_tokens, set(CLEF_ANCHORS.keys()))
+        self.assertEqual(clef_tokens - non_pitched_clefs, set(CLEF_ANCHORS.keys()))
 
     def test_max_ledger_lines(self) -> None:
         tokens = [

--- a/training/omr_datasets/convert_lieder.py
+++ b/training/omr_datasets/convert_lieder.py
@@ -322,11 +322,18 @@ class MeasureCutter:
             return 1
         return 0
 
-    def extract_measures(self, count: int) -> list[EncodedSymbol]:
+    def extract_measures(
+        self, count: int, always_include_time: bool = False
+    ) -> list[EncodedSymbol]:
         clefs = self.clefs.copy()
         key = self.key
         time = self.time
-        has_time = False
+        # Lieder pages are crops of one continuously rendered score, so a courtesy time
+        # signature is only visible where the source XML actually redeclares it. pdmx and
+        # musetrainer windows are each re-rendered standalone (see generate_xml), and that
+        # renderer always draws a time signature on a fresh score - so those callers pass
+        # always_include_time=True to keep the label in sync with the image.
+        has_time = always_include_time
         result: list[EncodedSymbol] = []
         for i in range(count):
             selected_measure = self.voice.pop(0)
@@ -457,31 +464,32 @@ def _split_file_into_staffs(
     return result
 
 
+def _leading_clefs(measure: Measure) -> list[EncodedSymbol]:
+    # The clefs of a measure always precede its notes/rests, but other preamble symbols
+    # (e.g. repeatStart on the very first measure) can come before them, so scan rather
+    # than assume fixed indices.
+    clefs = []
+    for symbol in measure:
+        if symbol.rhythm.startswith(("note", "rest")):
+            break
+        if symbol.rhythm.startswith("clef"):
+            clefs.append(symbol)
+    return clefs
+
+
 def _count_staffs(voice: list[Measure]) -> int:
     if len(voice) == 0:
         return 0
-    first_measure = voice[0]
-    if len(first_measure) == 0:
+    clefs = _leading_clefs(voice[0])
+    if len(clefs) == 0:
         return 0
-    if len(first_measure) < 3:
-        return 0
-    third_symbol = first_measure[2]
-    if third_symbol.rhythm.startswith("clef"):
-        return 2
-    return 1
+    return 2 if len(clefs) >= 2 else 1
 
 
 def is_grandstaff(voice: list[Measure]) -> bool:
     if len(voice) == 0:
         return False
-    first_measure = voice[0]
-    if len(first_measure) < 3:
-        return False
-    return (
-        first_measure[0].rhythm.startswith("clef")
-        and first_measure[1].rhythm == "chord"
-        and first_measure[2].rhythm.startswith("clef")
-    )
+    return len(_leading_clefs(voice[0])) >= 2
 
 
 def get_svg_voice_count(voice: list[Measure]) -> int:

--- a/training/omr_datasets/convert_musetrainer.py
+++ b/training/omr_datasets/convert_musetrainer.py
@@ -268,7 +268,7 @@ def _convert_file_impl(path: Path) -> list[str]:
             cutter.key = key
             cutter.time = time_sym
 
-            tokens = cutter.extract_measures(len(window_measures))
+            tokens = cutter.extract_measures(len(window_measures), always_include_time=True)
 
             if calc_ratio_of_tuplets(tokens) <= 0.2 and contains_only_supported_clefs(tokens):
                 tokens = strip_naturals(tokens)

--- a/training/omr_datasets/convert_musetrainer.py
+++ b/training/omr_datasets/convert_musetrainer.py
@@ -1,0 +1,356 @@
+import io
+import json
+import multiprocessing
+import os
+import random
+import signal
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PIL import Image
+
+from homr.circle_of_fifths import strip_naturals
+from homr.download_utils import download_file, unzip_file
+from homr.music_xml_generator import XmlGeneratorArguments, generate_xml, xml_to_string
+from homr.simple_logging import eprint
+from homr.staff_parsing import add_image_into_tr_omr_canvas
+from homr.transformer.configs import default_config
+from homr.transformer.vocabulary import EncodedSymbol, empty
+from homr.type_definitions import NDArray
+from training.omr_datasets.convert_lieder import (
+    MeasureCutter,
+    _count_staffs,
+    contains_only_supported_clefs,
+    is_grandstaff,
+)
+from training.omr_datasets.music_xml_parser import Measure, music_xml_string_to_tokens
+from training.transformer.training_vocabulary import (
+    calc_ratio_of_tuplets,
+    check_token_lines,
+    token_lines_to_str,
+)
+
+script_location = os.path.dirname(os.path.realpath(__file__))
+git_root = Path(script_location).parent.parent.absolute()
+dataset_root = os.path.join(git_root, "datasets")
+musetrainer_root = os.path.join(dataset_root, "musetrainer")
+musetrainer_train_index = os.path.join(musetrainer_root, "index.txt")
+
+_WINDOW_SIZE = 8
+_VEROVIO_FONTS = ["Leipzig", "Bravura", "Gootville", "Leland", "Petaluma"]
+_N_WORKERS = max(1, os.cpu_count() or 4)
+_TIMEOUT_SECONDS = 20
+_RENDER_TIMEOUT_SECONDS = _TIMEOUT_SECONDS
+
+
+def _read_mxl(path: Path) -> str:
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+        xml_name = next(
+            (n for n in names if n.endswith(".xml") and "/" not in n),
+            next((n for n in names if n.endswith(".xml")), None),
+        )
+        if xml_name is None:
+            raise ValueError(f"No XML found in {path}")
+        return zf.read(xml_name).decode("utf-8")
+
+
+def _context_at_measure(
+    voice: list[Measure], measure_idx: int, n_staffs: int
+) -> tuple[list[EncodedSymbol], EncodedSymbol, EncodedSymbol]:
+    if n_staffs >= 2:
+        clefs: list[EncodedSymbol] = [
+            EncodedSymbol("clef_G2", empty, empty, empty, empty, "upper"),
+            EncodedSymbol("clef_F4", empty, empty, empty, empty, "lower"),
+        ]
+    else:
+        clefs = [EncodedSymbol("clef_G2", empty, empty, empty, empty, "upper")]
+    key: EncodedSymbol = EncodedSymbol("keySignature_0")
+    time_sym: EncodedSymbol = EncodedSymbol("timeSignature/4")
+
+    for i in range(measure_idx):
+        for symbol in voice[i]:
+            if "clef" in symbol.rhythm:
+                idx = 1 if symbol.position == "lower" and len(clefs) > 1 else 0
+                clefs[idx] = symbol
+            elif "keySignature" in symbol.rhythm:
+                key = symbol
+            elif "timeSignature" in symbol.rhythm:
+                time_sym = symbol
+
+    return clefs, key, time_sym
+
+
+_DYNAMICS = ("pp", "p", "mp", "mf", "f", "ff", "fff", "sf", "sfz", "fp")
+_TEMPO_MARKS = (
+    ("Largo", 50),
+    ("Adagio", 70),
+    ("Andante", 90),
+    ("Moderato", 100),
+    ("Allegro", 120),
+    ("Vivace", 140),
+    ("Presto", 170),
+)
+
+
+def _insert_direction(measure: ET.Element, direction: ET.Element) -> None:
+    note_idx = next((i for i, child in enumerate(measure) if child.tag == "note"), len(measure))
+    measure.insert(note_idx, direction)
+
+
+def inject_musicxml_markings(xml_str: str) -> str:
+    try:
+        root = ET.fromstring(xml_str)  # noqa: S314
+    except ET.ParseError:
+        return xml_str
+
+    measures = root.findall(".//measure")
+    if not measures:
+        return xml_str
+
+    if random.random() < 0.40:
+        tempo_text, tempo_bpm = random.choice(_TEMPO_MARKS)
+        direction = ET.Element("direction", attrib={"placement": "above"})
+        dtype = ET.SubElement(direction, "direction-type")
+        ET.SubElement(dtype, "words").text = tempo_text
+        ET.SubElement(direction, "sound").set("tempo", str(tempo_bpm))
+        _insert_direction(measures[0], direction)
+
+    if random.random() < 0.60:
+        n = random.randint(1, min(3, len(measures)))
+        for measure in random.sample(measures, n):
+            dyn_tag = random.choice(_DYNAMICS)
+            direction = ET.Element("direction", attrib={"placement": "below"})
+            dtype = ET.SubElement(direction, "direction-type")
+            ET.SubElement(ET.SubElement(dtype, "dynamics"), dyn_tag)
+            _insert_direction(measure, direction)
+
+    return ET.tostring(root, encoding="unicode")
+
+
+def _render_svg_in_subprocess(
+    xml_str: str, scale: int, font: str, mnum_interval: int
+) -> str | None:
+    # Verovio can hang or crash on pathological input (observed empirically). Running it in a
+    # disposable subprocess with a hard timeout means a stuck render just gets killed - it can
+    # never leak a worker in the parent Pool the way an in-process hang or a signal-based
+    # timeout (which can crash mid-C-call) would.
+    request = json.dumps(
+        {"xml_str": xml_str, "scale": scale, "font": font, "mnum_interval": mnum_interval}
+    )
+    try:
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "training.omr_datasets.verovio_render_worker"],
+            input=request.encode(),
+            capture_output=True,
+            timeout=_RENDER_TIMEOUT_SECONDS,
+            cwd=git_root,
+            check=True,
+        )
+    except subprocess.TimeoutExpired:
+        eprint("Verovio rendering timed out")
+        return None
+    except subprocess.CalledProcessError as e:
+        # A segfault (the common case for pathological input) kills the process before it
+        # can write anything, so stderr is often empty - fall back to reporting the signal
+        # or exit code instead of staying silent.
+        stderr = e.stderr.decode(errors="replace").strip()
+        if not stderr:
+            stderr = (
+                f"killed by signal {signal.Signals(-e.returncode).name}"
+                if e.returncode < 0
+                else f"exit code {e.returncode}"
+            )
+        eprint("Verovio rendering failed:", stderr)
+        return None
+
+    try:
+        response = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        eprint("Verovio rendering returned invalid output:", e)
+        return None
+
+    svg: str | None = response.get("svg")
+    return svg
+
+
+def _tokens_to_svg(tokens: list[EncodedSymbol]) -> str | None:
+    try:
+        xml_el = generate_xml(XmlGeneratorArguments(), [tokens], "")
+        xml_str = inject_musicxml_markings(xml_to_string(xml_el))
+    except Exception as e:
+        eprint("XML generation failed:", e)
+        return None
+
+    try:
+        root = ET.fromstring(xml_str)  # noqa: S314
+        start = random.randint(1, 150)
+        for i, measure in enumerate(root.findall(".//measure")):
+            measure.set("number", str(start + i))
+        xml_str = ET.tostring(root, encoding="unicode")
+    except ET.ParseError:
+        pass
+
+    scale = random.randint(40, 80)
+    font = random.choice(_VEROVIO_FONTS)
+    mnum_interval = 1 if random.random() < 0.20 else 0
+
+    return _render_svg_in_subprocess(xml_str, scale, font, mnum_interval)
+
+
+def _svg_to_png(svg_str: str) -> NDArray | None:
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["rsvg-convert"],  # noqa: S607
+            input=svg_str.encode(),
+            capture_output=True,
+            timeout=_RENDER_TIMEOUT_SECONDS,
+            check=True,
+        )
+        rgba = Image.open(io.BytesIO(result.stdout)).convert("RGBA")
+        bg = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+        bg.paste(rgba, mask=rgba.split()[3])
+        img: NDArray = np.array(bg.convert("L"))
+    except subprocess.TimeoutExpired:
+        eprint("SVG rasterization timed out")
+        return None
+    except Exception as e:
+        eprint("SVG rasterization failed:", e)
+        return None
+
+    return add_image_into_tr_omr_canvas(img)
+
+
+def _convert_file_impl(path: Path) -> list[str]:
+    try:
+        xml_str = _read_mxl(path)
+    except Exception as e:
+        eprint("Failed to read", path, e)
+        return []
+
+    try:
+        voices = music_xml_string_to_tokens(xml_str)
+    except Exception as e:
+        eprint("Failed to parse", path, e)
+        return []
+
+    if not voices:
+        return []
+
+    voices_to_process = [v for v in voices if _count_staffs(v) >= 1]
+    if not voices_to_process:
+        return []
+
+    stem = path.stem
+    results: list[str] = []
+
+    for voice_idx, voice in enumerate(voices_to_process):
+        n_measures = len(voice)
+        if n_measures < 2:
+            continue
+
+        n_staffs = 2 if is_grandstaff(voice) else 1
+
+        window_start = 0
+        window_idx = 0
+        while window_start < n_measures:
+            end = min(window_start + _WINDOW_SIZE, n_measures)
+            window_measures = voice[window_start:end]
+
+            clefs, key, time_sym = _context_at_measure(voice, window_start, n_staffs)
+            cutter = MeasureCutter(list(window_measures))
+            cutter.clefs = clefs
+            cutter.key = key
+            cutter.time = time_sym
+
+            tokens = cutter.extract_measures(len(window_measures))
+
+            if calc_ratio_of_tuplets(tokens) <= 0.2 and contains_only_supported_clefs(tokens):
+                tokens = strip_naturals(tokens)
+                try:
+                    if len(tokens) > default_config.max_seq_len - 2:
+                        raise ValueError("Sequence too long")
+                    check_token_lines(tokens)
+                except ValueError:
+                    pass
+                else:
+                    svg_str = _tokens_to_svg(tokens)
+                    if svg_str is not None:
+                        img = _svg_to_png(svg_str)
+                        if img is not None:
+                            basename = f"{stem}-v{voice_idx}-w{window_idx}"
+                            img_path = os.path.join(musetrainer_root, basename + ".jpg")
+                            tok_path = os.path.join(musetrainer_root, basename + ".tokens")
+                            cv2.imwrite(img_path, img)
+                            with open(tok_path, "w") as f:
+                                f.write(token_lines_to_str(tokens))
+                            rel_img = str(Path(img_path).relative_to(git_root))
+                            rel_tok = str(Path(tok_path).relative_to(git_root))
+                            results.append(rel_img + "," + rel_tok + "\n")
+
+            window_start = end
+            window_idx += 1
+
+    return results
+
+
+def convert_musetrainer() -> None:
+    if not os.path.exists(musetrainer_root):
+        eprint("Downloading MuseTrainer from https://github.com/musetrainer/library")
+        archive = os.path.join(dataset_root, "musetrainer.zip")
+        download_file(
+            "https://github.com/musetrainer/library/archive/refs/heads/master.zip",
+            archive,
+        )
+        unzip_file(archive, dataset_root)
+        extracted = os.path.join(dataset_root, "library-master")
+        if os.path.exists(extracted):
+            os.rename(extracted, musetrainer_root)
+
+    os.makedirs(musetrainer_root, exist_ok=True)
+    mxl_files = list(Path(musetrainer_root).rglob("*.mxl"))
+    if not mxl_files:
+        eprint("No .mxl files found in", musetrainer_root)
+        return
+
+    eprint(f"Processing {len(mxl_files)} MuseTrainer files")
+
+    with open(musetrainer_train_index, "w") as index_f:
+        file_number = 0
+        skipped_files = 0
+        with multiprocessing.Pool(processes=_N_WORKERS, maxtasksperchild=2) as p:
+            async_results = [
+                (path, p.apply_async(_convert_file_impl, (path,))) for path in mxl_files
+            ]
+            for path, ar in async_results:
+                try:
+                    result = ar.get(timeout=_TIMEOUT_SECONDS)
+                except multiprocessing.TimeoutError:
+                    eprint("Timeout processing", path, "skipping")
+                    result = []
+                except Exception as e:
+                    eprint("Error", e)
+                    result = []
+                if result:
+                    for line in result:
+                        index_f.write(line)
+                    index_f.flush()
+                else:
+                    skipped_files += 1
+                file_number += 1
+                if file_number % 10 == 0:
+                    eprint(
+                        f"Processed {file_number}/{len(mxl_files)} files,",
+                        f"skipped {skipped_files} files",
+                    )
+
+    eprint("Done — index written to", musetrainer_train_index)
+
+
+if __name__ == "__main__":
+    convert_musetrainer()

--- a/training/omr_datasets/convert_pdmx.py
+++ b/training/omr_datasets/convert_pdmx.py
@@ -1,0 +1,239 @@
+import csv
+import multiprocessing
+import os
+import random
+import zipfile
+from itertools import zip_longest
+from pathlib import Path
+
+import cv2
+
+from homr.circle_of_fifths import strip_naturals
+from homr.download_utils import download_file, untar_file
+from homr.simple_logging import eprint
+from homr.transformer.configs import default_config
+from training.omr_datasets.convert_lieder import (
+    MeasureCutter,
+    _count_staffs,
+    contains_only_supported_clefs,
+    is_grandstaff,
+)
+from training.omr_datasets.convert_musetrainer import (
+    _N_WORKERS,
+    _TIMEOUT_SECONDS,
+    _WINDOW_SIZE,
+    _context_at_measure,
+    _svg_to_png,
+    _tokens_to_svg,
+)
+from training.omr_datasets.music_xml_parser import music_xml_string_to_tokens
+from training.transformer.training_vocabulary import (
+    calc_ratio_of_tuplets,
+    check_token_lines,
+    token_lines_to_str,
+)
+
+script_location = os.path.dirname(os.path.realpath(__file__))
+git_root = Path(script_location).parent.parent.absolute()
+dataset_root = os.path.join(git_root, "datasets")
+pdmx_root = os.path.join(dataset_root, "pdmx")
+pdmx_csv = os.path.join(pdmx_root, "PDMX.csv")
+pdmx_mxl_root = os.path.join(pdmx_root, "mxl")
+pdmx_out_root = os.path.join(pdmx_root, "out")
+pdmx_train_index = os.path.join(pdmx_root, "index.txt")
+
+_MAX_COMPLEXITY = 2
+_MAX_TRACKS = 2
+_TARGET_FILES = 10000  # ~50K images
+
+
+def _read_mxl(path: Path) -> str:
+    with zipfile.ZipFile(path) as zf:
+        names = zf.namelist()
+        xml_name = next(
+            (n for n in names if n.endswith(".xml") and "/" not in n),
+            next((n for n in names if n.endswith(".xml")), None),
+        )
+        if xml_name is None:
+            raise ValueError(f"No XML found in {path}")
+        return zf.read(xml_name).decode("utf-8")
+
+
+def _convert_file_impl(mxl_path: Path) -> list[str]:
+    try:
+        xml_str = _read_mxl(mxl_path)
+    except Exception as e:
+        eprint("Failed to read", mxl_path, e)
+        return []
+
+    try:
+        voices = music_xml_string_to_tokens(xml_str)
+    except Exception as e:
+        eprint("Failed to parse", mxl_path, e)
+        return []
+
+    if not voices:
+        return []
+
+    voices_to_process = [v for v in voices if _count_staffs(v) >= 1]
+    if not voices_to_process:
+        return []
+
+    stem = mxl_path.stem
+
+    rel_parts = mxl_path.relative_to(pdmx_mxl_root).parts
+    out_dir = os.path.join(pdmx_out_root, *rel_parts[:-1])
+    os.makedirs(out_dir, exist_ok=True)
+
+    results: list[str] = []
+
+    for voice_idx, voice in enumerate(voices_to_process):
+        n_measures = len(voice)
+        if n_measures < 2:
+            continue
+
+        n_staffs = 2 if is_grandstaff(voice) else 1
+
+        window_start = 0
+        window_idx = 0
+        while window_start < n_measures:
+            end = min(window_start + _WINDOW_SIZE, n_measures)
+            window_measures = voice[window_start:end]
+
+            clefs, key, time_sym = _context_at_measure(voice, window_start, n_staffs)
+            cutter = MeasureCutter(list(window_measures))
+            cutter.clefs = clefs
+            cutter.key = key
+            cutter.time = time_sym
+
+            tokens = cutter.extract_measures(len(window_measures))
+
+            if calc_ratio_of_tuplets(tokens) <= 0.2 and contains_only_supported_clefs(tokens):
+                tokens = strip_naturals(tokens)
+                try:
+                    if len(tokens) > default_config.max_seq_len - 2:
+                        raise ValueError("Sequence too long")
+                    check_token_lines(tokens)
+                except ValueError:
+                    pass
+                else:
+                    svg_str = _tokens_to_svg(tokens)
+                    if svg_str is not None:
+                        img = _svg_to_png(svg_str)
+                        if img is not None:
+                            basename = f"{stem}-v{voice_idx}-w{window_idx}"
+                            img_path = os.path.join(out_dir, basename + ".jpg")
+                            tok_path = os.path.join(out_dir, basename + ".tokens")
+                            cv2.imwrite(img_path, img)
+                            with open(tok_path, "w") as f:
+                                f.write(token_lines_to_str(tokens))
+                            rel_img = str(Path(img_path).relative_to(git_root))
+                            rel_tok = str(Path(tok_path).relative_to(git_root))
+                            results.append(rel_img + "," + rel_tok + "\n")
+
+            window_start = end
+            window_idx += 1
+
+    return results
+
+
+def _load_filtered_paths() -> list[Path]:
+    buckets: dict[tuple[int, int], list[Path]] = {}
+    with open(pdmx_csv, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            if row["subset:no_license_conflict"] != "True":
+                continue
+            if row["subset:all_valid"] != "True":
+                continue
+            try:
+                n_tracks = int(row["n_tracks"])
+                if n_tracks > _MAX_TRACKS:
+                    continue
+            except (ValueError, KeyError):
+                continue
+            try:
+                complexity = int(row["complexity"])
+                if complexity > _MAX_COMPLEXITY:
+                    continue
+            except (ValueError, KeyError):
+                continue
+            rel_mxl = row["mxl"].lstrip("./")
+            buckets.setdefault((n_tracks, complexity), []).append(Path(pdmx_root) / rel_mxl)
+
+    rng = random.Random(42)
+    for paths in buckets.values():
+        rng.shuffle(paths)
+
+    for key in sorted(buckets):
+        n_tracks, complexity = key
+        eprint(f"  tracks={n_tracks} complexity={complexity}: {len(buckets[key]):,} files")
+
+    sentinel = object()
+    result: list[Path] = []
+    for group in zip_longest(*[buckets[k] for k in sorted(buckets)], fillvalue=sentinel):
+        for item in group:
+            if item is not sentinel:
+                result.append(item)  # type: ignore[arg-type]
+            if len(result) >= _TARGET_FILES:
+                return result
+    return result
+
+
+def convert_pdmx() -> None:
+    os.makedirs(pdmx_root, exist_ok=True)
+
+    if not os.path.exists(pdmx_csv):
+        eprint("Downloading PDMX.csv (~214 MB)")
+        download_file(
+            "https://zenodo.org/api/records/15571083/files/PDMX.csv/content",
+            pdmx_csv,
+        )
+
+    if not os.path.exists(pdmx_mxl_root):
+        eprint("Downloading PDMX mxl.tar.gz (~1.8 GB)")
+        mxl_archive = os.path.join(pdmx_root, "mxl.tar.gz")
+        download_file(
+            "https://zenodo.org/api/records/15571083/files/mxl.tar.gz/content",
+            mxl_archive,
+        )
+        eprint("Extracting mxl.tar.gz")
+        untar_file(mxl_archive, pdmx_root)
+
+    os.makedirs(pdmx_out_root, exist_ok=True)
+
+    eprint("Reading CSV and applying filters")
+    mxl_paths = _load_filtered_paths()
+    eprint(f"{len(mxl_paths)} files pass pre-filters (c<={_MAX_COMPLEXITY}, tracks<={_MAX_TRACKS})")
+
+    with open(pdmx_train_index, "w") as index_f:
+        file_number = 0
+        skipped_files = 0
+        with multiprocessing.Pool(processes=_N_WORKERS, maxtasksperchild=2) as p:
+            async_results = [
+                (path, p.apply_async(_convert_file_impl, (path,))) for path in mxl_paths
+            ]
+            for path, ar in async_results:
+                try:
+                    result = ar.get(timeout=_TIMEOUT_SECONDS)
+                except multiprocessing.TimeoutError:
+                    eprint("Timeout processing", path, "skipping")
+                    result = []
+                if result:
+                    for line in result:
+                        index_f.write(line)
+                    index_f.flush()
+                else:
+                    skipped_files += 1
+                file_number += 1
+                if file_number % 10 == 0:
+                    eprint(
+                        f"Processed {file_number}/{len(mxl_paths)} files,",
+                        f"skipped {skipped_files} files",
+                    )
+
+    eprint("Done - index written to", pdmx_train_index)
+
+
+if __name__ == "__main__":
+    convert_pdmx()

--- a/training/omr_datasets/convert_pdmx.py
+++ b/training/omr_datasets/convert_pdmx.py
@@ -106,7 +106,7 @@ def _convert_file_impl(mxl_path: Path) -> list[str]:
             cutter.key = key
             cutter.time = time_sym
 
-            tokens = cutter.extract_measures(len(window_measures))
+            tokens = cutter.extract_measures(len(window_measures), always_include_time=True)
 
             if calc_ratio_of_tuplets(tokens) <= 0.2 and contains_only_supported_clefs(tokens):
                 tokens = strip_naturals(tokens)

--- a/training/omr_datasets/music_xml_parser.py
+++ b/training/omr_datasets/music_xml_parser.py
@@ -320,56 +320,82 @@ class TokensPart:
         self.tuplets = TupletState()
         self.tremolo = False
         self.divisions: int = 1
+        # Clefs queued by an after-barline declaration in the previous measure,
+        # not yet eligible to be flushed into the current one.
+        self.queued_clefs: dict[int, EncodedSymbol] = {}
+        # Queued clefs that became active once the measure they target started;
+        # still cancellable by an explicit clef in that same measure.
+        self.pending_clefs: dict[int, EncodedSymbol] = {}
+
+    def _ensure_current_measure(self) -> TokensMeasure:
+        """
+        MusicXML may split a measure's attributes across several <attributes>
+        elements, e.g. one with only divisions/time followed by one with the
+        clef. So the clef isn't guaranteed to be the very first symbol.
+        """
+        if self.current_measure is None:
+            self.current_measure = TokensMeasure()
+        return self.current_measure
+
+    def _flush_pending_clefs(self) -> None:
+        if not self.pending_clefs:
+            return
+        current_measure = self._ensure_current_measure()
+        for staff, symbol in self.pending_clefs.items():
+            current_measure.append_symbol_to_staff(staff, symbol)
+        self.pending_clefs = {}
 
     def append_clefs(self, clefs: list[tuple[EncodedSymbol, int]]) -> None:
-        current_measure = self.current_measure
-        if current_measure is not None:
-            for staff, clef in enumerate(clefs):
-                if clef[1] >= 0:
-                    current_measure.append_symbol_to_staff(clef[1], clef[0])
-                else:
-                    current_measure.append_symbol_to_staff(staff, clef[0])
-        else:
-            measure = TokensMeasure()
-            for staff, clef in enumerate(clefs):
-                measure.append_symbol_to_staff(staff, clef[0])
-            self.current_measure = measure
+        resolved = [
+            (clef[1] if clef[1] >= 0 else index, clef[0]) for index, clef in enumerate(clefs)
+        ]
+        # An explicit clef for a staff in this measure overrides any clef
+        # that was queued for it via after-barline in the previous measure.
+        for staff, _ in resolved:
+            self.pending_clefs.pop(staff, None)
+        self._flush_pending_clefs()
+        current_measure = self._ensure_current_measure()
+        for staff, symbol in resolved:
+            current_measure.append_symbol_to_staff(staff, symbol)
+
+    def queue_clefs_for_next_measure(self, clefs: list[tuple[EncodedSymbol, int]]) -> None:
+        """
+        A <clef after-barline="yes"> is printed at the end of the current
+        measure but only takes effect at the start of the next one.
+        """
+        for index, clef in enumerate(clefs):
+            staff = clef[1] if clef[1] >= 0 else index
+            self.queued_clefs[staff] = clef[0]
 
     def append_symbol(self, symbol: EncodedSymbol) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-        self.current_measure.append_symbol(symbol)
+        self._flush_pending_clefs()
+        self._ensure_current_measure().append_symbol(symbol)
 
     def mark_new_page(self) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-        self.current_measure.mark_new_page()
+        self._flush_pending_clefs()
+        self._ensure_current_measure().mark_new_page()
 
     def append_rest(
         self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
     ) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-        self.current_measure.append_rest(staff, is_chord, duration, invisible, symbol)
+        self._flush_pending_clefs()
+        self._ensure_current_measure().append_rest(staff, is_chord, duration, invisible, symbol)
 
     def append_note(
         self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
     ) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-        self.current_measure.append_note(staff, is_chord, duration, invisible, symbol)
+        self._flush_pending_clefs()
+        self._ensure_current_measure().append_note(staff, is_chord, duration, invisible, symbol)
 
     def append_position_change(self, duration: int) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-        self.current_measure.append_position_change(duration)
+        self._flush_pending_clefs()
+        self._ensure_current_measure().append_position_change(duration)
 
     def on_end_of_measure(self) -> None:
-        if self.current_measure is None:
-            raise ValueError("Expected to get clefs as first symbol")
-
-        self.measures.append(self.current_measure.complete_measure())
+        self.measures.append(self._ensure_current_measure().complete_measure())
         self.current_measure = TokensMeasure()
+        self.pending_clefs.update(self.queued_clefs)
+        self.queued_clefs = {}
         self.tuplets.on_end_of_measure()
 
     def get_measures(self) -> list[Measure]:
@@ -412,6 +438,7 @@ def _process_attributes(part: TokensPart, attribute: ET.Element) -> None:
     clefs = _children(attribute, "clef")
     if len(clefs) > 0:
         clefs_tokens: list[tuple[EncodedSymbol, int]] = []
+        deferred_clefs_tokens: list[tuple[EncodedSymbol, int]] = []
         for clef in clefs:
             sign = _text(_child(clef, "sign"))
             line = _text(_child(clef, "line"))
@@ -419,10 +446,15 @@ def _process_attributes(part: TokensPart, attribute: ET.Element) -> None:
             if has_octave_change:
                 raise ValueError("Octave change isn't supported")
             clef_number = int(clef.get("number", "1")) - 1
-            clefs_tokens.append(
-                (EncodedSymbol(f"clef_{sign}{line}", empty, empty, empty, empty), clef_number)
-            )
-        part.append_clefs(clefs_tokens)
+            token = (EncodedSymbol(f"clef_{sign}{line}", empty, empty, empty, empty), clef_number)
+            if clef.get("after-barline") == "yes":
+                deferred_clefs_tokens.append(token)
+            else:
+                clefs_tokens.append(token)
+        if clefs_tokens:
+            part.append_clefs(clefs_tokens)
+        if deferred_clefs_tokens:
+            part.queue_clefs_for_next_measure(deferred_clefs_tokens)
     keys = _children(attribute, "key")
     times = _children(attribute, "time")
     if len(keys) > 0:

--- a/training/omr_datasets/music_xml_parser.py
+++ b/training/omr_datasets/music_xml_parser.py
@@ -4,6 +4,7 @@ from typing import Iterable, SupportsIndex, TypeVar, overload
 from homr.music_xml_generator import DURATION_NAMES
 from homr.simple_logging import eprint
 from homr.transformer.vocabulary import (
+    VALID_TIME_SIGNATURE_DENOMINATORS,
     EncodedSymbol,
     empty,
     has_rhythm_symbol_a_position,
@@ -462,6 +463,8 @@ def _process_attributes(part: TokensPart, attribute: ET.Element) -> None:
         part.append_symbol(EncodedSymbol(f"keySignature_{int(fifths)}"))
     if len(times) > 0:
         beat_type = _text(_child(times[0], "beat-type"))
+        if not beat_type.isdigit() or int(beat_type) not in VALID_TIME_SIGNATURE_DENOMINATORS:
+            raise ValueError(f"Unsupported time signature denominator: {beat_type}")
         part.append_symbol(EncodedSymbol(f"timeSignature/{beat_type}"))
 
     style = _children(attribute, "measure-style")

--- a/training/omr_datasets/verovio_render_worker.py
+++ b/training/omr_datasets/verovio_render_worker.py
@@ -1,0 +1,38 @@
+import json
+import sys
+
+from homr.simple_logging import eprint
+
+
+def render(xml_str: str, scale: int, font: str, mnum_interval: int) -> str | None:
+    import verovio  # noqa: PLC0415 - lazy: must not be loaded in the parent training process
+
+    try:
+        tk = verovio.toolkit()
+        tk.setOptions(
+            {
+                "breaks": "none",
+                "adjustPageWidth": True,
+                "adjustPageHeight": True,
+                "scale": scale,
+                "font": font,
+                "mnumInterval": mnum_interval,
+            }
+        )
+        if not tk.loadData(xml_str):
+            return None
+        return tk.renderToSVG(1)
+    except Exception as e:
+        eprint("Verovio rendering failed:", e)
+        return None
+
+
+def main() -> None:
+    request = json.loads(sys.stdin.readline())
+    svg = render(request["xml_str"], request["scale"], request["font"], request["mnum_interval"])
+    sys.stdout.write(json.dumps({"svg": svg}))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/training/transformer/augraphy_augment.py
+++ b/training/transformer/augraphy_augment.py
@@ -1,0 +1,141 @@
+"""Augraphy document-degradation augmentation for training."""
+
+import os
+import tempfile
+from typing import Any
+
+import numpy as np
+
+from homr.type_definitions import NDArray
+
+_worker_tmpdir: str | None = None
+
+
+def _get_worker_tmpdir() -> str:
+    # Each DataLoader worker is a separate process; give it its own directory so
+    # augraphy's ./augraphy_cache/ writes don't collide across workers.
+    global _worker_tmpdir  # noqa: PLW0603
+    if _worker_tmpdir is None:
+        _worker_tmpdir = tempfile.mkdtemp(prefix=f"augraphy_{os.getpid()}_")
+    return _worker_tmpdir
+
+
+def apply_augraphy(image: NDArray) -> NDArray:
+    """Apply Augraphy document degradation. 5% no-op; returns input on any failure."""
+    if np.random.random() < 0.05:
+        return image
+
+    try:
+        pipeline = _build_pipeline()
+    except ImportError:
+        return image
+
+    saved_cwd = os.getcwd()
+    os.chdir(_get_worker_tmpdir())
+    try:
+        result = pipeline(image)
+        augmented: NDArray = result["output"] if isinstance(result, dict) else result
+        if augmented is None or augmented.shape[:2] != image.shape[:2]:
+            return image
+        if augmented.dtype != np.uint8:
+            augmented = np.clip(augmented, 0, 255).astype(np.uint8)
+        return augmented
+    except Exception:
+        return image
+    finally:
+        os.chdir(saved_cwd)
+
+
+def _build_pipeline(rng: np.random.Generator | None = None) -> Any:
+    try:
+        import augraphy  # noqa: PLC0415
+    except ImportError as exc:
+        raise ImportError("augraphy is required: pip install augraphy") from exc
+
+    r = rng.random if rng is not None else np.random.random
+
+    ink_phase = []
+
+    if r() < 0.20:
+        ink_phase.append(augraphy.InkBleed(intensity_range=(0.2, 0.5), p=1.0))
+
+    if r() < 0.50:
+        ink_phase.append(augraphy.LowInkRandomLines(count_range=(5, 15), p=1.0))
+
+    paper_phase: list[Any] = [augraphy.Brightness(brightness_range=(0.5, 1.5), p=1.0)]
+
+    if r() < 0.10:
+        try:
+            paper_phase.append(augraphy.BleedThrough(intensity_range=(0.5, 1.0), alpha=0.2, p=1.0))
+        except (AttributeError, TypeError):
+            pass
+
+    if r() < 0.25:
+        try:
+            paper_phase.append(
+                augraphy.LightingGradient(
+                    light_position=None,
+                    direction=None,
+                    max_brightness=255,
+                    min_brightness=0,
+                    mode="gaussian",
+                    transparency=0.92,
+                    p=1.0,
+                )
+            )
+        except (AttributeError, TypeError):
+            pass
+
+    post_phase = []
+
+    if r() < 0.90:
+        try:
+            post_phase.append(augraphy.DirtyScreen(clumsiness_range=(0.1, 1.0), p=1.0))
+        except (AttributeError, TypeError):
+            try:
+                post_phase.append(augraphy.DirtyScreen(p=1.0))
+            except AttributeError:
+                pass
+
+    if r() < 0.60:
+        try:
+            post_phase.append(augraphy.NoiseTexturize(sigma_range=(1, 2), p=1.0))
+        except AttributeError:
+            pass
+
+    if r() < 0.33:
+        try:
+            post_phase.append(augraphy.SubtleNoise(subtle_range=8, p=1.0))
+        except AttributeError:
+            pass
+
+    if r() < 0.50:
+        try:
+            post_phase.append(augraphy.Jpeg(quality_range=(60, 95), p=1.0))
+        except AttributeError:
+            pass
+
+    if r() < 0.20:
+        try:
+            if r() < 0.5:
+                post_phase.append(augraphy.DirtyRollers(p=1.0))
+            else:
+                post_phase.append(augraphy.DirtyDrum(p=1.0))
+        except AttributeError:
+            pass
+
+    if r() < 0.15:
+        try:
+            post_phase.append(augraphy.ShadowCast(p=1.0))
+        except AttributeError:
+            pass
+
+    if r() < 0.05:
+        post_phase.append(augraphy.LowInkRandomLines(count_range=(1, 3), p=1.0))
+
+    return augraphy.AugraphyPipeline(
+        ink_phase=ink_phase,
+        paper_phase=paper_phase,
+        post_phase=post_phase,
+        log=False,
+    )

--- a/training/transformer/data_loader.py
+++ b/training/transformer/data_loader.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from homr.simple_logging import eprint
 from homr.staff_parsing import add_image_into_tr_omr_canvas
-from homr.transformer.configs import Config
+from homr.transformer.configs import Config, default_config
 from homr.transformer.vocabulary import Vocabulary
 from training.transformer.image_utils import (
     distort_image,
@@ -61,7 +61,11 @@ class DataLoader:
         entry = self.corpus_list[idx]
         sample_filepath = os.path.join(git_root, entry["image"])
 
-        img = read_image_to_ndarray(sample_filepath)
+        try:
+            img = read_image_to_ndarray(sample_filepath)
+        except ValueError:
+            eprint(f"Warning: skipping corrupted image {sample_filepath}")
+            return self.__getitem__((idx + 1) % len(self))
 
         if self.is_validation:
             state = random.getstate()
@@ -103,9 +107,13 @@ def _filter_valid_samples(samples: list[str]) -> list[str]:
     # between what is visible on the image and the ground truth
     valid_samples: list[str] = []
     filter_count = 0
+    too_long_count = 0
     for entry in samples:
         image, token_file = entry.strip().split(",")
         tokens = read_tokens(token_file)
+        if len(tokens) > default_config.max_seq_len - 2:
+            too_long_count += 1
+            continue
         if max_ledger_lines(tokens) > MAX_ALLOWED_LEDGER_LINES:
             filter_count += 1
             continue
@@ -113,6 +121,8 @@ def _filter_valid_samples(samples: list[str]) -> list[str]:
 
     if filter_count > 0:
         eprint(f"Filtered out {filter_count} samples with too many ledger lines")
+    if too_long_count > 0:
+        eprint(f"Filtered out {too_long_count} samples with sequences longer than max_seq_len")
     return valid_samples
 
 

--- a/training/transformer/image_utils.py
+++ b/training/transformer/image_utils.py
@@ -1,20 +1,118 @@
+import functools
+from pathlib import Path
+
 import albumentations as A
 import cv2
 import numpy as np
 import torch
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 from homr.staff_dewarping import warp_image_randomly
 from homr.type_definitions import NDArray
+from training.transformer.augraphy_augment import apply_augraphy
+
+_texture_config: dict = {"dir": None, "paths": None}
+
+
+def set_texture_dir(path: str) -> None:
+    """Configure a directory of paper texture images for background augmentation."""
+    _texture_config["dir"] = path
+    _texture_config["paths"] = None
+
+
+def _get_texture_paths() -> list[str]:
+    if _texture_config["paths"] is None:
+        d = _texture_config["dir"]
+        if d is None:
+            _texture_config["paths"] = []
+        else:
+            p = Path(d)
+            _texture_config["paths"] = (
+                [str(f) for f in p.iterdir() if f.suffix.lower() in (".jpg", ".jpeg", ".png")]
+                if p.is_dir()
+                else []
+            )
+    paths: list[str] = _texture_config["paths"]
+    return paths
+
+
+_font_cache: dict = {"paths": None}
+_FONT_KEYWORDS: frozenset[str] = frozenset(
+    {"times", "liberation", "freeserif", "palatino", "georgia", "garamond", "edwin"}
+)
+
+
+def _get_annotation_font_paths() -> list[str]:
+    if _font_cache["paths"] is not None:
+        paths: list[str] = _font_cache["paths"]
+        return paths
+    search_dirs = [
+        Path("/usr/share/fonts"),
+        Path("/usr/local/share/fonts"),
+        Path.home() / ".fonts",
+        Path.home() / ".local/share/fonts",
+    ]
+    found: list[str] = []
+    for d in search_dirs:
+        if not d.is_dir():
+            continue
+        for pattern in ("*.ttf", "*.otf"):
+            for f in d.rglob(pattern):
+                if any(kw in f.stem.lower() for kw in _FONT_KEYWORDS):
+                    found.append(str(f))
+    _font_cache["paths"] = found
+    return found
+
+
+def apply_text_injection(image: NDArray) -> NDArray:
+    """Inject random alphanumeric fragments to simulate score annotations."""
+    h, w = image.shape[:2]
+    pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB)).convert("RGBA")
+    font_paths = _get_annotation_font_paths()
+    chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+    n_fragments = int(np.random.randint(1, 4))
+    for _ in range(n_fragments):
+        if np.random.random() < 0.4:
+            text = str(int(np.random.randint(0, 101)))
+        else:
+            length = int(np.random.randint(1, 5))
+            indices = np.random.randint(0, len(chars), size=length)
+            text = "".join(chars[int(i)] for i in indices)
+
+        font_size = int(np.random.uniform(0.08, 0.14) * h)
+        font_size = max(8, min(font_size, 36))
+
+        font: ImageFont.FreeTypeFont | ImageFont.ImageFont
+        if font_paths:
+            try:
+                font = ImageFont.truetype(str(np.random.choice(font_paths)), font_size)
+            except Exception:
+                font = ImageFont.load_default(size=font_size)
+        else:
+            font = ImageFont.load_default(size=font_size)
+
+        bbox = font.getbbox(text)
+        tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
+        x = int(np.random.uniform(0, max(1, w - tw)))
+        y = int(np.random.uniform(0, max(1, h - th)))
+
+        gray_val = int(np.random.uniform(20, 80))
+        opacity = int(np.random.uniform(0.6, 0.9) * 255)
+
+        text_layer = Image.new("RGBA", pil_img.size, (255, 255, 255, 0))
+        draw = ImageDraw.Draw(text_layer)
+        draw.text((x, y), text, fill=(gray_val, gray_val, gray_val, opacity), font=font)
+        pil_img = Image.alpha_composite(pil_img, text_layer)
+
+    result_bgr: NDArray = cv2.cvtColor(np.array(pil_img.convert("RGB")), cv2.COLOR_RGB2BGR)
+    return result_bgr
 
 
 def read_image_to_ndarray(path: str) -> NDArray:
     img: NDArray = cv2.imread(path, cv2.IMREAD_COLOR_BGR)  # type: ignore
     if img is None:
         raise ValueError("Failed to read image from " + path)
-
-    if len(img.shape) == 3 and img.shape[-1] == 4:
-        img = 255 - img[:, :, 3]
     return img
 
 
@@ -70,287 +168,110 @@ def add_margin(image: NDArray, top: int, bottom: int, left: int, right: int) -> 
     return out[..., 0] if squeeze else out
 
 
-def add_random_margins(
-    image: NDArray,
-    min_margin: int = 10,
-    max_margin: int = 100,
-    fill_white: bool = True,
-) -> NDArray:
-    """
-    Add random margins on all four sides of the image.
-
-    Args:
-        image: Input image (H, W) or (H, W, C)
-        min_margin: Minimum margin size in pixels
-        max_margin: Maximum margin size in pixels
-        fill_white: If True, use white (255) fill; otherwise use detected background
-
-    Returns:
-        Image with random margins added
-    """
-    top = np.random.randint(min_margin, max_margin + 1)
-    bottom = np.random.randint(min_margin, max_margin + 1)
-    left = np.random.randint(min_margin, max_margin + 1)
-    right = np.random.randint(min_margin, max_margin + 1)
-
-    if fill_white:
-        # Use pure white fill
-        if image.ndim == 2:
-            padded = np.pad(
-                image, ((top, bottom), (left, right)), mode="constant", constant_values=255
-            )
-        else:
-            padded = np.pad(
-                image, ((top, bottom), (left, right), (0, 0)), mode="constant", constant_values=255
-            )
-        return padded
-    else:
-        # Use existing add_margin with background detection
-        return add_margin(image, top, bottom, left, right)
-
-
-def apply_ink_fade(image: NDArray, p: float = 0.15) -> NDArray:
-    """
-    Apply gradient-based ink fading to simulate aged or faded ink.
-    This is more realistic than uniform brightness changes.
-
-    Args:
-        image: Input image
-        p: Probability of applying this augmentation
-
-    Returns:
-        Image with optional ink fade applied
-    """
-    if np.random.random() > p:
-        return image
-
-    h, w = image.shape[:2]
-
-    # Choose gradient type
-    gradient_type = np.random.choice(["linear", "radial", "noise"])
-
-    if gradient_type == "linear":
-        # Linear gradient in random direction
-        angle = np.random.uniform(0, 2 * np.pi)
-        x = np.arange(w)
-        y = np.arange(h)
-        xx, yy = np.meshgrid(x, y)
-        gradient = xx * np.cos(angle) + yy * np.sin(angle)
-        gradient = (gradient - gradient.min()) / (gradient.max() - gradient.min())
-    elif gradient_type == "radial":
-        # Radial gradient from random center
-        center_x = np.random.uniform(0, w)
-        center_y = np.random.uniform(0, h)
-        x = np.arange(w) - center_x
-        y = np.arange(h) - center_y
-        xx, yy = np.meshgrid(x, y)
-        gradient = np.sqrt(xx**2 + yy**2)
-        gradient = (gradient - gradient.min()) / (gradient.max() - gradient.min())
-    else:  # noise-based
-        # Smooth noise gradient
-        gradient = np.random.randn(h // 10, w // 10)
-        gradient = cv2.resize(gradient, (w, h), interpolation=cv2.INTER_LINEAR)
-        gradient = (gradient - gradient.min()) / (gradient.max() - gradient.min())
-
-    # Randomly flip gradient direction
-    if np.random.random() < 0.5:
-        gradient = 1 - gradient
-
-    # Apply subtle fade (max 30-40 brightness units to preserve legibility)
-    fade_strength = np.random.uniform(20, 40)
-    fade_mask = gradient * fade_strength
-
-    if image.ndim == 2:
-        faded = image.astype(np.float32) + fade_mask
-    else:
-        fade_mask = np.stack([fade_mask] * image.shape[2], axis=-1)
-        faded = image.astype(np.float32) + fade_mask
-
-    return np.clip(faded, 0, 255).astype(np.uint8)
-
-
-def apply_diverse_noise(image: NDArray, p: float = 0.5) -> NDArray:
-    """
-    Apply diverse noise patterns with varying shapes, sizes, and intensities.
-    This simulates real-world scanning artifacts and paper texture.
-
-    Args:
-        image: Input image
-        p: Probability of applying noise
-
-    Returns:
-        Image with diverse noise applied
-    """
-    if np.random.random() > p:
-        return image
-
-    result = image.copy().astype(np.float32)
-    h, w = image.shape[:2]
-
-    # Apply 1-3 different noise types
-    num_noise_types = np.random.randint(1, 4)
-
-    for _ in range(num_noise_types):
-        noise_type = np.random.choice(["patch", "gaussian", "salt_pepper"])
-
-        if noise_type == "patch":
-            # Patch-based noise with varying shapes and sizes
-            num_patches = np.random.randint(5, 20)
-            for _ in range(num_patches):
-                # Random patch size
-                patch_h = np.random.randint(5, 50)
-                patch_w = np.random.randint(5, 50)
-
-                # Random position
-                y = np.random.randint(0, max(1, h - patch_h))
-                x = np.random.randint(0, max(1, w - patch_w))
-
-                # Random noise variance
-                noise_std = np.random.uniform(5, 25)
-
-                # Create patch noise
-                patch_noise = np.random.normal(0, noise_std, (patch_h, patch_w))
-
-                # Random shape (rectangular or circular)
-                if np.random.random() < 0.3:
-                    # Circular mask
-                    cy, cx = patch_h // 2, patch_w // 2
-                    y_grid, x_grid = np.ogrid[:patch_h, :patch_w]
-                    mask = (y_grid - cy) ** 2 + (x_grid - cx) ** 2 <= (
-                        min(patch_h, patch_w) // 2
-                    ) ** 2
-                    patch_noise = patch_noise * mask
-
-                # Apply patch noise
-                if image.ndim == 2:
-                    result[y : y + patch_h, x : x + patch_w] += patch_noise
-                else:
-                    for c in range(image.shape[2]):
-                        result[y : y + patch_h, x : x + patch_w, c] += patch_noise
-
-        elif noise_type == "gaussian":
-            # Global Gaussian noise with random intensity
-            noise_std = np.random.uniform(3, 12)
-            if image.ndim == 2:
-                noise = np.random.normal(0, noise_std, (h, w))
-                result += noise
-            else:
-                for c in range(image.shape[2]):
-                    noise = np.random.normal(0, noise_std, (h, w))
-                    result[:, :, c] += noise
-
-        else:  # salt_pepper
-            # Salt and pepper noise
-            amount = np.random.uniform(0.001, 0.005)
-            num_salt = int(amount * h * w * 0.5)
-            num_pepper = int(amount * h * w * 0.5)
-
-            # Salt (white pixels)
-            coords_y = np.random.randint(0, h, num_salt)
-            coords_x = np.random.randint(0, w, num_salt)
-            if image.ndim == 2:
-                result[coords_y, coords_x] = 255
-            else:
-                result[coords_y, coords_x, :] = 255
-
-            # Pepper (black pixels)
-            coords_y = np.random.randint(0, h, num_pepper)
-            coords_x = np.random.randint(0, w, num_pepper)
-            if image.ndim == 2:
-                result[coords_y, coords_x] = 0
-            else:
-                result[coords_y, coords_x, :] = 0
-
-    return np.clip(result, 0, 255).astype(np.uint8)
-
-
 def apply_clahe(image: NDArray, p: float = 0.1) -> NDArray:
-    """
-    Apply Contrast Limited Adaptive Histogram Equalization (CLAHE) to amplify
-    existing noise and texture. This should be applied AFTER noise addition.
-
-    Args:
-        image: Input image
-        p: Probability of applying CLAHE (default 0.1 = 10% of images)
-
-    Returns:
-        Image with optional CLAHE applied
-    """
     if np.random.random() > p:
         return image
 
-    # Conservative CLAHE parameters to avoid artifacts
     clip_limit = np.random.uniform(2.0, 3.0)
-    tile_grid_size = (8, 8)
-
-    clahe = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=tile_grid_size)
+    clahe = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=(8, 8))
 
     if image.ndim == 2:
         return clahe.apply(image)
     else:
-        # Apply to each channel
         result = np.zeros_like(image)
         for c in range(image.shape[2]):
             result[:, :, c] = clahe.apply(image[:, :, c])
         return result
 
 
-def distort_image(image: NDArray, allow_occlusions: bool = False) -> NDArray:
-    """
-    Apply data augmentation to an image.
+def apply_ink_color_shift(image: NDArray) -> NDArray:
+    """Lighten dark ink pixels by 0-40 luma units to simulate non-pure-black ink."""
+    shift = int(np.random.randint(0, 41))
+    if shift == 0:
+        return image
+    luma = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    dark = luma < 80
+    result = image.copy()
+    result[dark] = np.clip(result[dark].astype(np.int32) + shift, 0, 255).astype(np.uint8)
+    return result
 
-    Args:
-        image: Input image array
-        allow_occlusions: If True, applies occlusiv that may hide musical elements.
-    """
 
-    # Add white margins as the staff detection would create something similiar
-    image = add_random_margins(image, min_margin=0, max_margin=20, fill_white=True)
+def apply_background_augmentation(image: NDArray) -> NDArray:
+    """Paper texture blend, gradient shading, and per-channel color cast."""
+    h, w = image.shape[:2]
+    img_f = image.astype(np.float32)
 
-    image, background_value = _add_random_gray_tone(
-        image, contrast_reduction_p=0.2, min_contrast_range=(30, 70)
-    )
+    luma = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    ink_mask = (255.0 - luma.astype(np.float32)) / 255.0
+    if image.ndim == 3:
+        ink_mask = ink_mask[:, :, np.newaxis]
 
-    transforms_list = [
-        A.Rotate(
-            limit=2,
-            border_mode=cv2.BORDER_CONSTANT,
-            fill=(255, 255, 255),
-            p=0.3,
-        ),
-        A.Perspective(
-            scale=(0.005, 0.015),
-            fit_output=not allow_occlusions,
-            border_mode=cv2.BORDER_CONSTANT,
-            fill=(255, 255, 255),
-            p=0.6,
-        ),
-        A.OneOf(
+    # Paper texture blend (70% when available)
+    textures = _get_texture_paths()
+    if textures and np.random.random() < 0.70:
+        tex_path = str(np.random.choice(textures))
+        tex = cv2.imread(tex_path)
+        if tex is not None:
+            if tex.ndim == 2:
+                tex = cv2.cvtColor(tex, cv2.COLOR_GRAY2BGR)
+            th, tw = tex.shape[:2]
+            tiled = np.tile(tex, (-(-h // th), -(-w // tw), 1))[:h, :w].astype(np.float32)
+            img_f = img_f * ink_mask + tiled * (1.0 - ink_mask)
+
+    # Gradient shading: linear + radial, ±10 and ±6 luma units
+    xg, yg = _gradient_grids(h, w)
+    gx = float(np.random.uniform(-10, 10))
+    gy = float(np.random.uniform(-10, 10))
+    radial = float(np.random.uniform(-6, 6)) * np.exp(-(xg**2 + yg**2) / 0.5)
+    shading = (gx * xg + gy * yg + radial).astype(np.float32)
+    img_f += shading[:, :, np.newaxis] if image.ndim == 3 else shading
+
+    # Per-channel color cast (BGR order: B ±6, G ±3, R ±4)
+    if image.ndim == 3:
+        cast = np.array(
             [
-                A.Morphological(scale=(1, 1), operation="erosion", p=1.0),
-                A.Morphological(scale=(2, 3), operation="dilation", p=1.0),
+                float(np.random.uniform(-6.0, 6.0)),
+                float(np.random.uniform(-3.0, 3.0)),
+                float(np.random.uniform(-4.0, 4.0)),
             ],
-            p=0.2,
-        ),
-        A.OneOf(
-            [
-                A.RandomBrightnessContrast(
-                    brightness_limit=0.3,
-                    contrast_limit=(-0.3, -0.1),
-                    p=1.0,
-                ),
-                A.RandomToneCurve(scale=0.3, p=1.0),
-                A.MultiplicativeNoise(multiplier=(0.8, 1.0), per_channel=True, p=1.0),
-            ],
-            p=0.2,
-        ),
-        A.ColorJitter(
-            brightness=0.2,
-            contrast=0.2,
-            saturation=0.1,
-            hue=0.05,
-            p=0.5,
-        ),
+            dtype=np.float32,
+        )
+        img_f += cast[np.newaxis, np.newaxis, :]
+
+    return np.clip(img_f, 0, 255).astype(np.uint8)
+
+
+@functools.lru_cache(maxsize=16)
+def _gradient_grids(h: int, w: int) -> tuple[NDArray, NDArray]:
+    xs = np.linspace(-1.0, 1.0, w, dtype=np.float32)
+    ys = np.linspace(-1.0, 1.0, h, dtype=np.float32)
+    xg, yg = np.meshgrid(xs, ys)
+    return xg, yg
+
+
+_MIN_STAFF_CONTRAST = 60
+
+
+def _enforce_min_staff_contrast(image: NDArray, ink_mask: NDArray) -> NDArray:
+    """Darken ink pixels that became too bright relative to background after augmentation."""
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    bg_pixels = gray[~ink_mask] if (~ink_mask).any() else gray.ravel()
+    bg_level = int(np.percentile(bg_pixels, 75))
+    ceiling = bg_level - _MIN_STAFF_CONTRAST
+    if ceiling <= 0:
+        return image
+    too_light = ink_mask & (gray > ceiling)
+    if not too_light.any():
+        return image
+    result = image.copy()
+    result[too_light] = np.clip(result[too_light].astype(np.int32), 0, ceiling).astype(np.uint8)
+    return result
+
+
+def _make_geometric_transforms(allow_occlusions: bool) -> A.Compose:
+    transforms_list: list[A.BasicTransform] = [
+        A.Rotate(limit=2, border_mode=cv2.BORDER_CONSTANT, fill=255, p=0.5),
+        A.Perspective(scale=(0.005, 0.015), fill=255, p=0.3),
         A.OneOf(
             [
                 A.GaussianBlur(blur_limit=(3, 5), sigma_limit=(0.1, 0.5), p=1.0),
@@ -358,160 +279,51 @@ def distort_image(image: NDArray, allow_occlusions: bool = False) -> NDArray:
             ],
             p=0.3,
         ),
-        A.OneOf(
-            [
-                A.GaussNoise(
-                    std_range=(0.02, 0.06),
-                    mean_range=(0.0, 0.0),
-                    per_channel=False,
-                    noise_scale_factor=0.25,
-                    p=1.0,
-                ),
-                A.ISONoise(color_shift=(0.01, 0.05), intensity=(0.1, 0.3), p=1.0),
-            ],
-            p=0.5,
-        ),
     ]
     if allow_occlusions:
-        transforms_list.extend(
-            [
-                A.RandomShadow(
-                    shadow_roi=(0, 0, 1, 1),
-                    num_shadows_limit=(1, 3),
-                    shadow_dimension=5,
-                    p=0.2,
-                ),
-                A.CoarseDropout(
-                    num_holes_range=(2, 8),
-                    hole_height_range=(10, 30),
-                    hole_width_range=(20, 60),
-                    fill=255,
-                    p=0.4,
-                ),
-                A.RandomFog(
-                    fog_coef_range=(0.1, 0.3),
-                    alpha_coef=0.1,
-                    p=0.2,
-                ),
-            ]
+        transforms_list.append(
+            A.CoarseDropout(
+                num_holes_range=(2, 8),
+                hole_height_range=(10, 30),
+                hole_width_range=(20, 60),
+                fill=255,
+                p=0.4,
+            ),
         )
-
-    transform = A.Compose(transforms_list)
-
-    transformed = transform(image=image)
-    augmented_image = transformed["image"]
-
-    augmented_image = apply_ink_fade(augmented_image, p=0.15)
-    augmented_image = apply_diverse_noise(augmented_image, p=0.5)
-    augmented_image = apply_clahe(augmented_image, p=0.1)
-
-    pil_image = Image.fromarray(augmented_image)
-    augmented_image = warp_image_randomly(pil_image)
-    augmented_array = np.array(augmented_image)
-
-    paper_texture = np.random.normal(loc=240, scale=8, size=augmented_array.shape).astype(np.uint8)
-    paper_alpha = 0.2
-    augmented_array = cv2.addWeighted(
-        augmented_array, 1 - paper_alpha, paper_texture, paper_alpha, 0
-    )
-
-    augmented_array = _apply_vignette(augmented_array)
-
-    augmented_array = add_random_margins(
-        augmented_array, min_margin=0, max_margin=20, fill_white=True
-    )
-
-    return augmented_array
+    return A.Compose(transforms_list)
 
 
-def _apply_vignette(image: NDArray) -> NDArray:
-    """Apply random asymmetric vignette effect to simulate scanner/camera artifacts."""
-    rows, cols = image.shape[:2]
-
-    # Randomized Gaussian parameters
-    sigma_x = np.random.uniform(cols / 4, cols)
-    sigma_y = np.random.uniform(rows / 4, rows)
-    center_x = np.random.uniform(0, cols)
-    center_y = np.random.uniform(0, rows)
-
-    # Generate coordinate grids
-    x = np.arange(cols) - center_x
-    y = np.arange(rows) - center_y
-    x_grid, y_grid = np.meshgrid(x, y)
-
-    # Optional rotation
-    theta = np.random.uniform(0, 2 * np.pi)
-    x_rot = x_grid * np.cos(theta) + y_grid * np.sin(theta)
-    y_rot = -x_grid * np.sin(theta) + y_grid * np.cos(theta)
-
-    # Create asymmetric Gaussian vignette
-    mask = np.exp(-0.5 * ((x_rot**2 / sigma_x**2) + (y_rot**2 / sigma_y**2)))
-    mask = mask / mask.max()
-
-    # Scale mask to subtle effect (0.9–1.0)
-    mask = 0.9 + 0.1 * mask
-
-    # Optional channel variation for color images
-    if len(image.shape) == 3 and image.shape[2] == 3:
-        mask = np.stack([mask * np.random.uniform(0.9, 1.0) for _ in range(3)], axis=-1)
-
-    return (image * mask).astype(np.uint8)
+_geometric_transforms: dict[bool, A.Compose] = {}
 
 
-def _add_random_gray_tone(
-    image_arr: NDArray, contrast_reduction_p: float, min_contrast_range: tuple[int, int] = (50, 70)
-) -> tuple[NDArray, int]:
-    """
-    Add a random gray background tone while ensuring minimum contrast is maintained.
-    This simulates different paper colors and scanning conditions.
-    """
-    if len(image_arr.shape) == 2:
-        gray = image_arr
-    else:
-        gray = cv2.cvtColor(image_arr, cv2.COLOR_BGR2GRAY)
+def distort_image(image: NDArray, allow_occlusions: bool = False) -> NDArray:
+    # Staff dewarping
+    image = np.array(warp_image_randomly(Image.fromarray(image)))
 
-    lightest_pixel_value = _find_lighest_non_white_pixel(gray)
+    # Geometric
+    if allow_occlusions not in _geometric_transforms:
+        _geometric_transforms[allow_occlusions] = _make_geometric_transforms(allow_occlusions)
+    image = _geometric_transforms[allow_occlusions](image=image)["image"]
 
-    # Occasionally use lower minimum contrast for more challenging cases
-    if np.random.random() < contrast_reduction_p:
-        minimum_contrast = np.random.randint(min_contrast_range[0], min_contrast_range[1])
-    else:
-        minimum_contrast = 70
+    # Capture ink locations after geometry, before brightness augmentation
+    _pre_gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY) if image.ndim == 3 else image
+    ink_mask = _pre_gray < 128
 
-    pure_white = 255
-    if lightest_pixel_value >= pure_white - minimum_contrast:
-        return image_arr, pure_white
+    # Ink and background
+    image = apply_ink_color_shift(image)
+    image = apply_background_augmentation(image)
 
-    strongest_possible_gray = lightest_pixel_value + minimum_contrast
-    random_gray_value = np.random.randint(strongest_possible_gray, pure_white)
+    # Annotation injection
+    if np.random.random() < 0.35:
+        image = apply_text_injection(image)
 
-    if random_gray_value >= pure_white:
-        return image_arr, random_gray_value
+    # Document degradation
+    image = apply_augraphy(image)
 
-    # Create mask for background pixels
-    if len(image_arr.shape) == 3:
-        mask = np.all(image_arr > random_gray_value, axis=-1)
-    else:
-        mask = image_arr > random_gray_value
+    # Local contrast
+    image = apply_clahe(image, p=0.1)
 
-    # Add jitter to background for texture
-    jitter = np.random.randint(-5, 5, size=mask.shape)
-    gray_bg = np.clip(random_gray_value + jitter, 0, pure_white)
+    # Ensure staff lines remain visible despite brightness/degradation augmentation
+    image = _enforce_min_staff_contrast(image, ink_mask)
 
-    # Apply background
-    if len(image_arr.shape) == 3:
-        image_arr[mask] = np.stack([gray_bg[mask]] * 3, axis=-1)
-    else:
-        image_arr[mask] = gray_bg[mask]
-
-    return image_arr, random_gray_value
-
-
-def _find_lighest_non_white_pixel(gray: NDArray) -> int:
-    """Find the lightest pixel value that isn't pure white (background)."""
-    pure_white = 255
-    valid_pixels = gray[gray < pure_white]
-    if valid_pixels.size > 0:
-        return valid_pixels.max()
-    else:
-        return pure_white
+    return image

--- a/training/transformer/train.py
+++ b/training/transformer/train.py
@@ -21,6 +21,11 @@ from training.omr_datasets.convert_grandstaff import (
     grandstaff_train_index,
 )
 from training.omr_datasets.convert_lieder import convert_lieder, lieder_train_index
+from training.omr_datasets.convert_musetrainer import (
+    convert_musetrainer,
+    musetrainer_train_index,
+)
+from training.omr_datasets.convert_pdmx import convert_pdmx, pdmx_train_index
 from training.omr_datasets.convert_primus import (
     convert_primus_dataset,
     primus_train_index,
@@ -112,6 +117,12 @@ def _check_datasets_are_present(selected_datasets: list[str]) -> list[str]:
 
         if dataset == lieder_train_index and not os.path.exists(lieder_train_index):
             convert_lieder()
+
+        if dataset == musetrainer_train_index and not os.path.exists(musetrainer_train_index):
+            convert_musetrainer()
+
+        if dataset == pdmx_train_index and not os.path.exists(pdmx_train_index):
+            convert_pdmx()
     return selected_datasets
 
 
@@ -135,24 +146,17 @@ def train_transformer(
             shutil.rmtree(os.path.join(git_root, checkpoint_folder))
 
     dataset_index = [lieder_train_index, grandstaff_train_index, primus_train_index]
+    dataset_weights = [1.0, 1.0, 1.0]
     if distribute.is_rank0():
         _check_datasets_are_present(dataset_index)
     distribute.barrier()
 
-    if smoke_test:
-        number_of_files = -1
-        train_index = load_and_mix_training_sets(
-            dataset_index,
-            [1.0, 1.0, 1.0],
-            number_of_files,
-        )
-    else:
-        number_of_files = -1
-        train_index = load_and_mix_training_sets(
-            dataset_index,
-            [1.0, 1.0, 1.0],
-            number_of_files,
-        )
+    number_of_files = -1
+    train_index = load_and_mix_training_sets(
+        dataset_index,
+        dataset_weights,
+        number_of_files,
+    )
 
     config = Config()
     datasets = load_dataset(train_index, config, val_split=0.1)

--- a/training/transformer/train.py
+++ b/training/transformer/train.py
@@ -145,8 +145,14 @@ def train_transformer(
         if distribute.is_rank0():
             shutil.rmtree(os.path.join(git_root, checkpoint_folder))
 
-    dataset_index = [lieder_train_index, grandstaff_train_index, primus_train_index]
-    dataset_weights = [1.0, 1.0, 1.0]
+    dataset_index = [
+        lieder_train_index,
+        grandstaff_train_index,
+        primus_train_index,
+        pdmx_train_index,
+        musetrainer_train_index,
+    ]
+    dataset_weights = [1.0, 1.0, 1.0, 1.0, 1.0]
     if distribute.is_rank0():
         _check_datasets_are_present(dataset_index)
     distribute.barrier()

--- a/training/validate_music_xml_conversion.py
+++ b/training/validate_music_xml_conversion.py
@@ -1,4 +1,5 @@
 import difflib
+import xml.etree.ElementTree as ET
 
 from homr.music_xml_generator import XmlGeneratorArguments, generate_xml
 from training.omr_datasets.music_xml_parser import music_xml_file_to_tokens
@@ -10,7 +11,7 @@ def validate_conversion(file: str) -> bool:
     tmp = file.replace(".tokens", ".musicxml.tmp")
 
     xml = generate_xml(XmlGeneratorArguments(None, None, None), [expected], "")
-    xml.write(tmp)
+    ET.ElementTree(xml).write(tmp, encoding="unicode", xml_declaration=True)
 
     actual = music_xml_file_to_tokens(tmp)
     flat_list = [x for xxs in actual for xs in xxs for x in xs]


### PR DESCRIPTION
AI Disclaimer: Another run which largely relied on Claude Code

The transcoda paper: https://arxiv.org/pdf/2605.10835

The synthetic approach is roughly this:

- Take a dataset and parse it into the internal format (tokens in our case)
- From the internal dataset, render an image (in our case tokens->musicxml->image)
- You now have an image which most likely matches exactly the ground truth data

This approach has the downside that the images become perhaps too clean. Everything which is nor part of your internal format will be removed. Transcoda therefore injects certain symbols again.

Suggestion: We already have a pretty clean pipeline build on Lieder, Primus and grandstaff. I think we should continue using that to have some more noisy examples (meaning examples with symbols which are not in our internal format and which use a different music font/renderer). And that we only add the Transcoda approach for the two new dataset musetrainer (rather tiny) and PDMX (large).