### PR TITLE
Fix --read-staff-positions: color/grayscale crash, lost title, lost grand-staff content

### DIFF
--- a/homr/main.py
+++ b/homr/main.py
@@ -188,6 +188,11 @@ def process_image(
                 debug, image, staff_position_files, config.selected_staff
             )
             title = ""
+            # parse_staffs() expects a grayscale image (cv2.findContours requires it),
+            # matching what the normal detect_staffs_in_image() path hands it
+            # (predictions.preprocessed). Apply the same CLAHE preprocessing here so the
+            # two code paths feed the symbol-recognition encoder consistent input.
+            image = color_adjust.apply_clahe(image)
         else:
             multi_staffs, image, debug, title_future = detect_staffs_in_image(image_path, config)
         debug_cleanup = debug
@@ -204,7 +209,8 @@ def process_image(
             config=transformer_config,
         )
 
-        title = title_future.result(60)
+        if not config.read_staff_positions:
+            title = title_future.result(60)
         eprint("Found title:", title)
 
         eprint("Writing XML", result_staffs)

--- a/homr/staff_position_save_load.py
+++ b/homr/staff_position_save_load.py
@@ -57,7 +57,8 @@ def load_staff_positions(
             if len(parts) % constants.number_of_lines_on_a_staff != 0:
                 continue  # Ignore invalid lines
 
-            _, norm_centerx, norm_centery, norm_width, norm_height = map(float, parts)
+            staff_class, norm_centerx, norm_centery, norm_width, norm_height = map(float, parts)
+            is_grandstaff = staff_class != 0
 
             width = norm_width * img_width
             height = norm_height * img_height
@@ -75,6 +76,7 @@ def load_staff_positions(
             if selected_staff >= 0 and line_index != selected_staff:
                 staff = dummy_staff_from_rect(bounding_box, image.shape)
                 if staff is not None:
+                    staff.is_grandstaff = is_grandstaff
                     staffs.append(MultiStaff([staff], []))
                 continue
 
@@ -83,6 +85,7 @@ def load_staff_positions(
                 staff = dummy_staff_from_rect(bounding_box, image.shape)
             min_staff_width = 10
             if staff is not None and staff.max_x - staff.min_x > min_staff_width:
+                staff.is_grandstaff = is_grandstaff
                 staffs.append(MultiStaff([staff], []))
         except Exception as e:
             eprint("Skipping staff due to error:", e)


### PR DESCRIPTION
## What this fixes

The `--read-staff-positions` flag lets you replay a hand-corrected staff layout instead of re-running the full detector (you first dump positions with `--write-staff-positions`, edit the file, then feed it back in). For me, the feature was broken — three separate bugs in the code path.

## The three bugs

1. **It crashes immediately.** The code loads a color image but the staff-parsing function expects grayscale. Every run failed with an OpenCV error.

2. **It crashes again on the title.** Once the first bug (above) was fixed, the code tried to read a "title" value that's never set when you're replaying positions (it's only set on a normal detection run). This throws a `NameError`.

3. **It silently drops every grand staff's bass clef** — the most important bug. The saved position file marks whether each staff is a "grand staff" (i.e., has a bass clef), but when loading the file back in, that flag was read and then thrown away. So every reloaded staff was treated as a plain (treble-only) staff, even if nothing was actually wrong with it. On a real piano score, this collapsed a 5-system page down to a single staff with ~5 measures — even with an *unmodified*, correct position file.

## The fix

- Convert the image to grayscale the same way the normal detection path does, before parsing staffs.
- Only read the "title" value when we're *not* replaying saved positions.
- Actually keep the grand-staff flag when reconstructing each staff from the saved file.

## How I verified it

- Existing tests pass (two unrelated modules already fail on `main` due to a missing dependency).
- Reproduced a real bug on a piano score: one system's bass clef was outside the detected crop. Fixed it by hand-editing the dumped position file and confirmed the bass measures now show correct content.
- Confirmed that an *unmodified* dump of a healthy page now round-trips correctly (same staff/measure counts as a fresh detection) — this was broken before due to bug #3.

## Note to reviewers

These three bugs are independent — happy to split into separate commits/PRs if you'd prefer, but they all showed up while debugging the same end-to-end scenario.
