### PR TITLE
update doc

### DIFF
--- a/Benchmark.md
+++ b/Benchmark.md
@@ -131,7 +131,7 @@ The display uses `<` for deleted tokens (in reference, missing from output), `>`
 
 ## Benchmark results
 
-All results are mean OMR-NED in % over the samples where the tool produced output. Means are only comparable between tools when coverage is similar.
+All results are mean OMR-NED in % over the samples where the tool produced output. Means are only comparable between tools when coverage is similar. For performance on latest homr model, refer to `Training.md` for details.
 
 ## native parser
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The easiest way to get started is using `uvx` (`uv` must be installed). Note tha
 
 - Clone the repository
 - Install dependencies for:
-  - GPU (requires CUDA): `poetry install --only main,gpu`
-  - CPU: `poetry install --only main`
-  - Development: `poetry install`
+  - Inference: `poetry install --only main (--extras gpu)`
+  - Development: `poetry install (--extras gpu)`
+  - Note that `--extras gpu` should be added to use GPU, otherwise only CPU is used.
 - Run the program using `poetry run homr <image>`
 - The resulting MusicXML file will be saved in the same directory as the input image
 - To combine the MusicXML results from multiple images, you can use [relieur](https://github.com/papoteur-mga/relieur)

--- a/Training.md
+++ b/Training.md
@@ -85,6 +85,7 @@ Transformer Smoke Test: 5%
 System Level: Total: 5.7 diffs, SER: 4.2%
 System Level after adding https://github.com/liebharc/homr/issues/110: Total: 5.5 diffs, SER: 4.1%
 Polish scores: OMR-NED 24.30%
+SMB scores: OMR-NED 22.06%
 
 Training with lieder+grandstaff+primux+pdmx+musetrainer datasets.
 


### PR DESCRIPTION
- README.md: after #114 , gpu dependency should be installed via `--extras gpu`
- Training.md: update SMB benchmark result on Run 426. [smb_new.log](https://github.com/user-attachments/files/29996040/smb_new.log)
- Benchmark.md: That's what I want to discuss. Should we update it as well? And besides, I notice benchmark results are uploaded to [release page](https://github.com/liebharc/homr/releases/tag/benchmark), so maybe I should do the same this time. If so, then we need to think about how to give it a name for each run.