### PR TITLE
run benchmark on multi-thread

### DIFF
--- a/validation/ned_benchmark.py
+++ b/validation/ned_benchmark.py
@@ -1,3 +1,5 @@
+# flake8: noqa: T201
+
 """
 OMR-NED benchmark framework.
 
@@ -37,9 +39,12 @@ Example queries:
 
 import contextlib
 import os
+import queue
 import signal
 import statistics
 import sys
+import threading
+import time
 import traceback
 from collections.abc import Callable, Iterator
 from pathlib import Path
@@ -239,9 +244,40 @@ def update_ned_scores(
         _print_stats("Pitch NED   ", [r.pitch_ned for r in results])
 
 
+class Sample:
+    def __init__(self, sample_id: str, kern_text: str, image_path: Path) -> None:
+        self.sample_id = sample_id
+        self.kern_text = kern_text
+        self.image_path = image_path
+
+    def set_success(self, raw_output: str) -> None:
+        self.raw_output = raw_output
+        self.error = ""
+
+    def set_failure(self, error: str) -> None:
+        self.raw_output = ""
+        self.error = error
+
+
+class SampleBatch:
+    def __init__(self, index: int, samples: list[Sample]) -> None:
+        self.index = index
+        self.samples = samples
+
+    def begin(self) -> None:
+        self.time = time.perf_counter()
+
+    def end(self) -> None:
+        self.time = time.perf_counter() - self.time
+        print(
+            f"\n--- Batch {self.index} ({len(self.samples)} samples) done in {self.time:.1f}s ---"
+        )
+
+
 def run_benchmark(
-    samples: list[tuple[str, str, Path]],
+    samples: list[Sample],
     tool: Callable[[str, Path | None], str],
+    num_workers: int,
     limit: int | None = None,
     verbose: bool = False,
     output_db: str | None = None,
@@ -281,7 +317,7 @@ def run_benchmark(
     failures: list[tuple[str, str]] = []
 
     samples = samples[:limit]
-    active = [s for s in samples if s[0] not in skip_ids]
+    active = [s for s in samples if s.sample_id not in skip_ids]
     skipped = len(samples) - len(active)
 
     if xml_parser in ("musicdiff", "musicdiff_detailed"):
@@ -289,29 +325,52 @@ def run_benchmark(
 
     if hasattr(tool, "batch_run") and active:
         # Batch mode: split into chunks so progress is visible after each batch.
-        chunks = [active[i : i + batch_size] for i in range(0, len(active), batch_size)]
-        n_chunks = len(chunks)
-        done = 0
-        for chunk_idx, chunk in enumerate(chunks, start=1):
-            print(  # noqa: T201
-                f"\n--- Batch {chunk_idx}/{n_chunks} "
-                f"({done + 1}–{done + len(chunk)} of {len(active)}) ---"
-            )
-            batch_results: list[tuple[str | None, str | None]] = tool.batch_run(chunk)
-            for (sample_id, kern_text, _image), (raw_output, error) in zip(
-                chunk, batch_results, strict=False
-            ):
-                if error is not None or raw_output is None:
+        pending: queue.Queue[SampleBatch] = queue.Queue()
+        completed: queue.Queue[SampleBatch] = queue.Queue()
+        for i in range(0, len(active), batch_size):
+            index_batch = i // batch_size + 1
+            samples_batch = active[i : i + batch_size]
+            pending.put(SampleBatch(index_batch, samples_batch))
+
+        num_batches = pending.qsize()
+        num_workers = min(num_workers, num_batches)
+
+        print(f"start {num_batches} batches with {num_workers} workers")
+
+        def _worker() -> None:
+            while True:
+                try:
+                    batch = pending.get_nowait()
+                except queue.Empty:
+                    return
+                batch.begin()
+                tool.batch_run(batch.samples)
+                batch.end()
+                completed.put(batch)
+
+        workers = [
+            threading.Thread(target=_worker, name=f"benchmark-worker-{i}")
+            for i in range(num_workers)
+        ]
+        start_time = time.perf_counter()
+        for w in workers:
+            w.start()
+
+        for _ in range(num_batches):
+            batch = completed.get()
+
+            for sample in batch.samples:
+                if sample.error:
                     _record_failure(
-                        sample_id, kern_text, error or "unknown error", failures, db, verbose
+                        sample.sample_id, sample.kern_text, sample.error, failures, db, verbose
                     )
                 else:
                     try:
                         with _sample_timeout():
                             _record_success(
-                                sample_id,
-                                kern_text,
-                                raw_output,
+                                sample.sample_id,
+                                sample.kern_text,
+                                sample.raw_output,
                                 results,
                                 db,
                                 kern_parser,
@@ -319,36 +378,45 @@ def run_benchmark(
                             )
                     except Exception as e:  # noqa: BLE001
                         _record_failure(
-                            sample_id,
-                            kern_text,
+                            sample.sample_id,
+                            sample.kern_text,
                             str(e),
                             failures,
                             db,
                             verbose,
                             e,
-                            actual_text=raw_output,
+                            actual_text=sample.raw_output,
                         )
-            done += len(chunk)
+
+        for w in workers:
+            w.join()
+
+        print(f"All batch done in {(time.perf_counter() - start_time):.1f}s, ")
     else:
         # Single-sample mode.
-        for sample_id, kern_text, image in active:
-            raw_output = None
+        for sample in active:
             try:
                 with _sample_timeout():
-                    raw_output = tool(kern_text, image)
+                    tool(sample.kern_text, sample.image_path)
                     _record_success(
-                        sample_id, kern_text, raw_output, results, db, kern_parser, xml_parser
+                        sample.sample_id,
+                        sample.kern_text,
+                        sample.raw_output,
+                        results,
+                        db,
+                        kern_parser,
+                        xml_parser,
                     )
             except Exception as e:  # noqa: BLE001
                 _record_failure(
-                    sample_id,
-                    kern_text,
+                    sample.sample_id,
+                    sample.kern_text,
                     str(e),
                     failures,
                     db,
                     verbose,
                     e,
-                    actual_text=raw_output,
+                    actual_text=sample.raw_output,
                 )
 
     if db is not None:

--- a/validation/polish-scores.py
+++ b/validation/polish-scores.py
@@ -12,7 +12,7 @@ import argparse
 import tempfile
 from pathlib import Path
 
-from validation.ned_benchmark import run_benchmark, update_ned_scores
+from validation.ned_benchmark import Sample, run_benchmark, update_ned_scores
 from validation.tools import TOOLS
 
 
@@ -31,8 +31,7 @@ def _add_kern_header(kern: str) -> str:
 
 def get_polish_scores_samples(
     image_dir: Path,
-) -> list[tuple[str, str, Path]]:
-    """Yield (sample_id, kern_text, image_path) for each sample in btrkeks/polish-scores."""
+) -> list[Sample]:
     from datasets import Image, load_dataset  # type: ignore  # noqa: PLC0415
 
     ds = load_dataset("btrkeks/polish-scores")["train"]
@@ -43,13 +42,14 @@ def get_polish_scores_samples(
         kern = _add_kern_header(sample["transcription_kern"])
         image_path = image_dir / f"{i}.png"
         image_path.write_bytes(sample["image"]["bytes"])
-        result.append((str(i), kern, image_path))
+        result.append(Sample(str(i), kern, image_path))
     return result
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="OMR-NED benchmark for btrkeks/polish-scores.")
     parser.add_argument("--limit", type=int, default=None, help="Only process N samples.")
+    parser.add_argument("--workers", type=int, default=1, help="Number of threads to use.")
     parser.add_argument("--verbose", action="store_true", help="Print traceback on failure.")
     parser.add_argument("--output", type=str, default=None, help="Path to SQLite output file.")
     parser.add_argument(
@@ -116,6 +116,7 @@ def main() -> None:
         run_benchmark(
             get_polish_scores_samples(Path(image_dir)),
             tool,
+            args.workers,
             limit=args.limit,
             verbose=args.verbose,
             output_db=output_db,

--- a/validation/smb.py
+++ b/validation/smb.py
@@ -16,17 +16,11 @@ import argparse
 import tempfile
 from pathlib import Path
 
-from validation.ned_benchmark import run_benchmark, update_ned_scores
+from validation.ned_benchmark import Sample, run_benchmark, update_ned_scores
 from validation.tools import TOOLS
 
 
-def get_smb_samples(image_dir: Path) -> list[tuple[str, str, Path]]:
-    """Yield (sample_id, kern_text, image_path) for each page in PRAIG/SMB.
-
-    Passes the full page image to allow proper end-to-end OMR evaluation.
-    Ground truth priority: page.kern > top-level kern > concatenated region kern.
-    image_path is only set when image_dir is provided and the page has an image.
-    """
+def get_smb_samples(image_dir: Path) -> list[Sample]:
     from datasets import Image, load_dataset  # type: ignore  # noqa: PLC0415
 
     ds = load_dataset("PRAIG/SMB")["test"]
@@ -43,13 +37,14 @@ def get_smb_samples(image_dir: Path) -> list[tuple[str, str, Path]]:
         image_path = image_dir / f"{i}.png"
         image_path.write_bytes(sample["image"]["bytes"])
 
-        result.append((str(i), kern, image_path))
+        result.append(Sample(str(i), kern, image_path))
     return result
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="OMR-NED benchmark for PRAIG/SMB.")
     parser.add_argument("--limit", type=int, default=None, help="Only process N samples.")
+    parser.add_argument("--workers", type=int, default=1, help="Number of threads to use.")
     parser.add_argument("--verbose", action="store_true", help="Print traceback on failure.")
     parser.add_argument("--output", type=str, default=None, help="Path to SQLite output file.")
     parser.add_argument(
@@ -116,6 +111,7 @@ def main() -> None:
         run_benchmark(
             get_smb_samples(image_dir=Path(image_dir)),
             tool,
+            args.workers,
             limit=args.limit,
             verbose=args.verbose,
             output_db=output_db,

--- a/validation/tools.py
+++ b/validation/tools.py
@@ -1,3 +1,5 @@
+# flake8: noqa: S101
+
 """
 OMR tools: callables with signature (kern_text: str, image: Path | None) -> str.
 
@@ -14,7 +16,6 @@ To add a new tool: implement a callable with the signature above and add it to T
 
 import copy
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -22,6 +23,8 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+
+from validation.ned_benchmark import Sample
 
 ToolFn = Callable[[str, "Path | None"], str]
 
@@ -210,48 +213,29 @@ class HomrTool:
 
     def batch_run(
         self,
-        samples: list[tuple[str, str, Path | None]],
-    ) -> list[tuple[str | None, str | None]]:
-        """
-        Process all samples in one homr invocation.
-
-        Returns a list of (output_xml, error_message) parallel to samples.
-        output_xml is None (and error_message set) when a sample failed.
-        """
-        results: list[tuple[str | None, str | None]] = []
-
+        samples: list[Sample],
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
-            stem_by_index: list[str | None] = []
 
-            for sample_id, _kern, image in samples:
-                if image is None:
-                    stem_by_index.append(None)
-                    continue
-                safe = re.sub(r"[^A-Za-z0-9_-]", "_", sample_id)
-                dst = tmp / (safe + image.suffix)
-                # Avoid name collisions by appending a counter when needed.
-                if dst.exists():
-                    dst = tmp / (safe + f"_{os.urandom(4).hex()}" + image.suffix)
-                shutil.copy(image, dst)
-                stem_by_index.append(dst.stem)
+            for sample in samples:
+                assert sample.image_path
+                dst = tmp / f"{sample.sample_id}{sample.image_path.suffix}"
+                dst.symlink_to(sample.image_path.resolve())
 
             try:
                 _run_homr_on_dir(tmp)
             except RuntimeError as e:
-                return [(None, str(e))] * len(samples)
+                for sample in samples:
+                    sample.set_failure(str(e))
+                return
 
-            for stem in stem_by_index:
-                if stem is None:
-                    results.append((None, "no image provided for this sample"))
-                    continue
-                xml_path = tmp / (stem + ".musicxml")
+            for sample in samples:
+                xml_path = tmp / f"{sample.sample_id}.musicxml"
                 if xml_path.exists():
-                    results.append((xml_path.read_text(encoding="utf-8"), None))
+                    sample.set_success(xml_path.read_text(encoding="utf-8"))
                 else:
-                    results.append((None, f"homr produced no .musicxml for {stem}"))
-
-        return results
+                    sample.set_failure(f"homr produced no .musicxml for {sample.sample_id}")
 
 
 def transcoda(kern_text: str, image: Path | None) -> str:
@@ -324,16 +308,17 @@ class SmtTool:
     def __call__(self, kern_text: str, image: Path | None) -> str:
         if image is None:
             raise ValueError("SMT requires an image; the dataset may not provide one.")
-        results = self.batch_run([("_", "", image)])
-        output, error = results[0]
+        samples = [Sample("_", "", image)]
+        self.batch_run(samples)
+        output, error = samples[0].raw_output, samples[0].error
         if error:
             raise RuntimeError(error)
         return output  # type: ignore[return-value]
 
     def batch_run(
         self,
-        samples: list[tuple[str, str, Path | None]],
-    ) -> list[tuple[str | None, str | None]]:
+        samples: list[Sample],
+    ) -> None:
         """
         Process all samples in one SMT invocation (model loaded once).
 
@@ -342,18 +327,9 @@ class SmtTool:
         """
         self._check_paths()
 
-        results: list[tuple[str | None, str | None]] = [
-            (None, "no image provided for this sample") for _ in samples
-        ]
-        valid: list[tuple[int, Path]] = [
-            (i, image) for i, (_, _, image) in enumerate(samples) if image is not None
-        ]
-        if not valid:
-            return results
-
         with tempfile.TemporaryDirectory() as tmpdir:
             paths_file = Path(tmpdir) / "paths.json"
-            paths_file.write_text(json.dumps([str(img) for _, img in valid]))
+            paths_file.write_text(json.dumps([str(sample.image_path) for sample in samples]))
 
             proc = subprocess.run(  # noqa: S603
                 [  # noqa: S607
@@ -372,18 +348,16 @@ class SmtTool:
             if proc.returncode != 0:
                 stderr = proc.stderr.decode("utf-8", errors="replace")
                 error = f"SMT exited with code {proc.returncode}\n{stderr[:1000]}"
-                for orig_idx, _ in valid:
-                    results[orig_idx] = (None, error)
-                return results
+                for sample in samples:
+                    sample.set_failure(error)
+                return
 
             batch_results: list[dict] = json.loads(proc.stdout.decode("utf-8"))
-            for (orig_idx, _), br in zip(valid, batch_results, strict=True):
+            for sample, br in zip(samples, batch_results, strict=True):
                 if br["ok"]:
-                    results[orig_idx] = (_ensure_kern_header(br["kern"]), None)
+                    sample.set_success(_ensure_kern_header(br["kern"]))
                 else:
-                    results[orig_idx] = (None, br["error"])
-
-        return results
+                    sample.set_failure(br["error"])
 
 
 def oemer(kern_text: str, image: Path | None) -> str:


### PR DESCRIPTION
## Motivation

Benchmarks take a long time to run. Since it's an important way to evaluate model and find optimization opportunities, it is worthwhile to speed up this process.

I profiled the process and found that most of the time is spent on CPU-side. GPU-side (i.e. segment and transformer inference) accounts for < 50%. Modern CPUs typically have 4+ cores, so obviously it can speed up using multiple threads (cores).

## Implementation

The existing code already divides the dataset into batches (i.e. `chunks` in the code), with 10 samples per batch (i.e. `batch_size=10`). So we just use these batches in the multi-thread execution flow:

1. Place all N batches into the `pending` queue.
2. Start multiple worker threads. Each worker process a batch, and then places the result into the `completed` queue, and get a new batch.
3. Main thread find a newly completed batch (from `completed` queue), and prints the progress information and writes the result to the database.

## Results

I measured the runtime on the Polish Scores dataset:

* 1 thread: 769.2 seconds
* 2 threads: 454.1 seconds — 1.7× speedup
* 3 threads: 341.1 seconds — 2.25× speedup
* 4 threads: 289.1 seconds — 2.66× speedup

We do get some speedup! But please note that optimization is hardware-dependent. On a machine with a strong CPU but a weak GPU, GPU inference is more likely to become the bottleneck, in which case multi-thread may provide poor improvement.

I would welcome benchmark results from other hardware configurations and look forward to receiving feedback! Simply add `--workers 3` will make it work, like `poetry run python -m validation.polish-scores --tool homr --workers 3`

## Other Changes

Again I also made several code refactor. The existing code in `run_benchmark()` makes extensive use of tuples, which makes the meaning of variables hard to understand. I replaced these with classes whose named fields clearly express their intent. Also added `set_success` and `set_failure` methods, making the control flow easier to follow.
