### PR TITLE
Fixed staff detection errors

### DIFF
--- a/homr/bounding_boxes.py
+++ b/homr/bounding_boxes.py
@@ -31,7 +31,20 @@ def calculate_edges_of_rotated_rectangle(
 
 
 def do_polygons_overlap(poly1: cvt.MatLike, poly2: cvt.MatLike) -> bool:
-    # Check if any point of one ellipse is inside the other ellipse
+    # A vertex-containment check ("is a corner of one polygon inside the other") is not
+    # sufficient: two long, thin, near-parallel rectangles (e.g. two staffs' bounding boxes
+    # with slightly opposite rotation) can overlap heavily along their shared middle while
+    # every corner of each stays outside the other - the overlap region is bounded by edge
+    # crossings, not by either polygon containing the other's vertices. Use a proper convex
+    # polygon intersection (both boxPoints-derived polygons here are convex) as the primary
+    # check instead of reimplementing edge-intersection tests by hand.
+    area, _ = cv2.intersectConvexConvex(poly1.astype(np.float32), poly2.astype(np.float32))
+    if area > 0:
+        return True
+
+    # Two polygons that merely touch (share an edge or corner, zero-width contact) are
+    # still considered "overlapping" by callers - intersectConvexConvex reports zero area
+    # for that degenerate case, so fall back to the boundary-inclusive vertex check for it.
     for point in poly1:
         if cv2.pointPolygonTest(poly2, (float(point[0]), float(point[1])), False) >= 0:
             return True

--- a/homr/brace_dot_detection.py
+++ b/homr/brace_dot_detection.py
@@ -19,6 +19,41 @@ def prepare_brace_dot_image(symbols: NDArray, staff: NDArray) -> NDArray:
     return cv2.dilate(out, kernel)
 
 
+def _trim_symbol_to_core_span(symbol: RotatedBoundingBox) -> RotatedBoundingBox:
+    """
+    Recover a brace/bracket candidate's true vertical span even if it merged
+    with unrelated ink during preprocessing. A real brace is wide (it
+    bulges), while ink it can accidentally fuse with, such as a neighboring
+    staff's clef or a chain of note stems, is comparatively thin. We keep
+    only the rows that are close to the blob's own widest row, using a
+    threshold relative to that blob (not an absolute pixel count), so this
+    works regardless of scan resolution or how much extra ink got attached.
+    """
+    x, y, w, h = cv2.boundingRect(symbol.contours)
+    if h <= 0 or w <= 0:
+        return symbol
+    mask = np.zeros((h, w), dtype=np.uint8)
+    cv2.drawContours(mask, [symbol.contours - (x, y)], -1, 255, thickness=cv2.FILLED)
+    row_widths = (mask > 0).sum(axis=1)
+    max_width = row_widths.max()
+    if max_width == 0:
+        return symbol
+    core_rows = np.where(row_widths >= max_width * constants.brace_core_width_ratio)[0]
+    if len(core_rows) == 0:
+        return symbol
+    core_min_y = y + int(core_rows.min())
+    core_max_y = y + int(core_rows.max()) + 1
+    core_height = core_max_y - core_min_y
+    if core_height <= 0:
+        return symbol
+    new_box = (
+        (symbol.center[0], (core_min_y + core_max_y) / 2),
+        (symbol.size[0], core_height),
+        symbol.angle,
+    )
+    return RotatedBoundingBox(new_box, symbol.contours, symbol.debug_id)
+
+
 def _filter_for_tall_elements(
     brace_dot: list[RotatedBoundingBox], staffs: list[Staff]
 ) -> list[RotatedBoundingBox]:
@@ -26,6 +61,11 @@ def _filter_for_tall_elements(
     We filter elements in two steps:
     1. Use a rough unit size estimate to reduce the data size
     2. Find the closest staff and take its unit size to take warping into account
+
+    Also drops candidates narrower than min_width_for_brace_dot_candidate here (see its
+    definition in homr/constants.py) - a fixed pixel width tied to the dilation kernel that
+    built these candidates, not to unit size, so it belongs in this rough/absolute pass
+    rather than the per-staff unit-size-relative pass below.
     """
     rough_unit_size = staffs[0].average_unit_size
     symbols_larger_than_rough_estimate = [
@@ -33,6 +73,7 @@ def _filter_for_tall_elements(
         for symbol in brace_dot
         if symbol.size[1] > constants.min_height_for_brace_rough(rough_unit_size)
         and symbol.size[0] < constants.max_width_for_brace_rough(rough_unit_size)
+        and symbol.size[0] >= constants.min_width_for_brace_dot_candidate
     ]
     result = []
     for symbol in symbols_larger_than_rough_estimate:
@@ -145,6 +186,7 @@ def find_braces_brackets_and_grand_staff_lines(
     """
     Connect staffs from multiple voices or grand staffs by searching for brackets and grand staffs.
     """
+    brace_dot = [_trim_symbol_to_core_span(symbol) for symbol in brace_dot]
     brace_dot = _filter_for_tall_elements(brace_dot, staffs)
     result = []
     for i, staff in enumerate(staffs):

--- a/homr/constants.py
+++ b/homr/constants.py
@@ -74,3 +74,24 @@ NOTEHEAD_SIZE_RATIO = 1.285714  # width/height
 
 grandstaff_x_distance_threshold_factor = 5
 grandstaff_y_overlap_threshold_factor = 0.5
+
+# A brace/bracket candidate blob can end up merged with unrelated ink that
+# happens to touch it during preprocessing (e.g. a neighboring staff's clef).
+# Such contamination is reliably thinner than the brace itself, so we keep
+# only the vertical range where the blob is at least this fraction as wide
+# as its own widest row, which recovers the true brace span regardless of
+# how much extra ink got attached to it.
+brace_core_width_ratio = 0.5
+
+# prepare_brace_dot_image's morphological dilation (homr/brace_dot_detection.py) uses a
+# 5px-wide kernel to bridge small gaps in brace/bracket ink into single blobs. A whole-system
+# bracket that crosses a staff line's own ink can occasionally break into two contours there:
+# the main bracket (correctly wide) plus a small, sparse leftover fragment too thin to fully
+# dilate back up to kernel width. That leftover is small enough to fit entirely within a
+# single staff pair's span, so it can still score well in _score_brace_with_staff_pair despite
+# being noise, not a real brace - this is an absolute pixel width tied to the kernel itself,
+# not to staff unit size, since it is about the morphology op, not the music engraving.
+# 5 (not 4): observed leftover fragments were 2-4px wide, while every genuine candidate
+# (barline connectors, real braces) observed across smb/polish-scores/testdata was >=5px -
+# exactly the dilation kernel's own width.
+min_width_for_brace_dot_candidate = 5

--- a/homr/main.py
+++ b/homr/main.py
@@ -195,9 +195,7 @@ def process_image(
             # two code paths feed the symbol-recognition encoder consistent input.
             image = color_adjust.apply_clahe(image)
         else:
-            multi_staffs, image, debug, title_future, _ = detect_staffs_in_image(
-                image_path, config
-            )
+            multi_staffs, image, debug, title_future, _ = detect_staffs_in_image(image_path, config)
         debug_cleanup = debug
 
         transformer_config = Config()

--- a/homr/main.py
+++ b/homr/main.py
@@ -195,7 +195,9 @@ def process_image(
             # two code paths feed the symbol-recognition encoder consistent input.
             image = color_adjust.apply_clahe(image)
         else:
-            multi_staffs, image, debug, title_future = detect_staffs_in_image(image_path, config)
+            multi_staffs, image, debug, title_future, _ = detect_staffs_in_image(
+                image_path, config
+            )
         debug_cleanup = debug
 
         transformer_config = Config()
@@ -238,7 +240,7 @@ def process_image(
 
 def detect_staffs_in_image(
     image_path: str, config: ProcessingConfig
-) -> tuple[list[MultiStaff], NDArray, Debug, Future[str]]:
+) -> tuple[list[MultiStaff], NDArray, Debug, Future[str], int]:
     predictions, debug = load_and_preprocess_predictions(
         image_path, config.enable_debug, config.enable_cache, config.segnet_use_gpu
     )
@@ -300,7 +302,7 @@ def detect_staffs_in_image(
 
     debug.write_all_bounding_boxes_alternating_colors("notes", multi_staffs, notes)
 
-    return multi_staffs, predictions.preprocessed, debug, title_future
+    return multi_staffs, predictions.preprocessed, debug, title_future, len(staffs)
 
 
 def get_all_image_files_in_folder(folder: str) -> list[str]:

--- a/homr/model.py
+++ b/homr/model.py
@@ -428,28 +428,71 @@ class MultiStaff(DebugDrawable):
     """
 
     def _score_brace_with_staff_pair(
-        self, symbol: RotatedBoundingBox, upper_staff: Staff, lower_staff: Staff
+        self,
+        symbol: RotatedBoundingBox,
+        upper_staff: Staff,
+        lower_staff: Staff,
+        staff_above: "Staff | None" = None,
+        staff_below: "Staff | None" = None,
     ) -> float:
         unit_size = float(np.median([upper_staff.average_unit_size, lower_staff.average_unit_size]))
         x_distance_threshold = constants.grandstaff_x_distance_threshold_factor * unit_size
         y_overlap_threshold = constants.grandstaff_y_overlap_threshold_factor * symbol.size[1]
 
-        symbol_min_x = symbol.center[0]
-        staff_min_x = min(upper_staff.min_x, lower_staff.min_x)
-        x_distance = abs(staff_min_x - symbol_min_x)
-
         symbol_min_y = symbol.center[1] - symbol.size[1] / 2
         symbol_max_y = symbol.center[1] + symbol.size[1] / 2
+
+        # A real grand-staff brace hugs only the two staffs it embraces and stops
+        # short of any neighboring staff. A candidate that reaches past the
+        # midpoint towards a staff outside the pair is not a brace for this pair
+        # at all -- it's more likely a whole-system bracket or barline that
+        # happens to touch several unrelated staffs (e.g. in an a-cappella trio
+        # with no piano, where any adjacent two of the three staffs would
+        # otherwise look like a plausible grand-staff pair). Overlap-ratio checks
+        # against the pair's own span can't catch this, because for a bracket
+        # spanning N staffs, any 2 consecutive ones already cover 2/N of it --
+        # comfortably over 50% whenever N <= 4. Checking against the actual
+        # neighboring staff's position catches it directly, regardless of N.
+        if staff_above is not None:
+            midpoint_above = (staff_above.max_y + upper_staff.min_y) / 2
+            if symbol_min_y < midpoint_above:
+                return 0
+        if staff_below is not None:
+            midpoint_below = (lower_staff.max_y + staff_below.min_y) / 2
+            if symbol_max_y > midpoint_below:
+                return 0
+
+        # Distance to whichever staff's left edge is closer, not to the smaller
+        # of the two min_x values. The two staffs of a system are normally
+        # aligned at their left edge, but staff detection can occasionally let
+        # one staff's box bleed further left than the other (e.g. picking up a
+        # stray mark near a title or instrument name). Requiring closeness to
+        # the min of both mins makes the match fragile to whichever staff is
+        # noisy; requiring closeness to at least one is robust to either staff
+        # being the noisy one.
+        symbol_min_x = symbol.center[0]
+        x_distance = min(
+            abs(upper_staff.min_x - symbol_min_x), abs(lower_staff.min_x - symbol_min_x)
+        )
+
         y_overlap = min(symbol_max_y, lower_staff.max_y) - max(symbol_min_y, upper_staff.min_y)
 
-        if (
+        if not (
             x_distance < x_distance_threshold
             and y_overlap > y_overlap_threshold
             and y_overlap > x_distance
         ):
-            return y_overlap - x_distance
-        else:
             return 0
+
+        # Score by intersection-over-union of the symbol with this staff pair's
+        # own span, rather than by raw overlap in pixels. A brace_dot blob that
+        # also touches a third, unrelated staff (e.g. it merged with that
+        # staff's clef ink during preprocessing) spans much more than the true
+        # pair and would otherwise win purely because its absolute overlap is
+        # larger, even when it fits some other pair's span far more tightly.
+        union = max(symbol_max_y, lower_staff.max_y) - min(symbol_min_y, upper_staff.min_y)
+        iou = y_overlap / union if union > 0 else 0.0
+        return iou - x_distance / x_distance_threshold
 
     class GrandStaffPair:
         def __init__(self, pair_index: list[int], score: float):
@@ -471,9 +514,13 @@ class MultiStaff(DebugDrawable):
         pair_scores: list[MultiStaff.GrandStaffPair] = []
         # step1: we try each two staffs combination, like (0,1), (1,2), (2,3), ...
         for i in range(len(self.staffs) - 1):
+            staff_above = self.staffs[i - 1] if i > 0 else None
+            staff_below = self.staffs[i + 2] if i + 2 < len(self.staffs) else None
             best_score = max(
                 (
-                    self._score_brace_with_staff_pair(symbol, self.staffs[i], self.staffs[i + 1])
+                    self._score_brace_with_staff_pair(
+                        symbol, self.staffs[i], self.staffs[i + 1], staff_above, staff_below
+                    )
                     for symbol in brace_dot
                 ),
             )

--- a/homr/staff_detection.py
+++ b/homr/staff_detection.py
@@ -453,12 +453,6 @@ def find_staff_anchors(
                     if (line.max_x - line.min_x)
                     > constants.is_short_connected_line(estimated_unit_size)
                 ]
-            if len(connected_lines) == constants.number_of_lines_on_a_staff - 1:
-                extrapolated = _extrapolate_missing_staff_line(
-                    connected_lines, symbol, estimated_unit_size
-                )
-                if extrapolated is not None:
-                    connected_lines = extrapolated
             if not len(connected_lines) == constants.number_of_lines_on_a_staff:
                 continue
             if not are_lines_parallel(connected_lines, estimated_unit_size):
@@ -611,63 +605,6 @@ def filter_unusual_anchors(anchors: list[StaffAnchor]) -> list[StaffAnchor]:
             continue
         result.append(anchor)
     return result
-
-
-def _cluster_anchors_by_staff(anchors: list[StaffAnchor]) -> list[list[StaffAnchor]]:
-    """
-    Group anchors whose Y-ranges overlap - i.e. anchors found at different x-positions
-    (or via a clef vs. a bar line) for what is physically the same staff - into one
-    cluster per staff. Anchors are otherwise unordered/unrelated at this point, so this
-    is the only way to tell "these belong to the same staff" from "these are neighbors".
-    """
-    by_y = sorted(anchors, key=lambda a: a.min_y)
-    clusters: list[list[StaffAnchor]] = []
-    cluster_max_y = float("-inf")
-    for anchor in by_y:
-        if clusters and anchor.min_y <= cluster_max_y:
-            clusters[-1].append(anchor)
-        else:
-            clusters.append([anchor])
-        cluster_max_y = max(a.max_y for a in clusters[-1])
-    return clusters
-
-
-def cap_anchor_zones_to_neighbors(anchors: list[StaffAnchor]) -> None:
-    """
-    StaffAnchor.zone extends 5 unit-sizes past the anchor's own staff lines to catch
-    ledger-line notes above/below. In densely packed multi-staff systems (e.g. a choral
-    score with 3+ close staves per system) that extension can reach into a neighboring
-    staff only a few unit-sizes away, pulling its line fragments into this staff's
-    detection in find_raw_staffs_by_connecting_line_fragments and producing a
-    contaminated, oversized RawStaff. Cap every anchor's zone at the midpoint to the
-    nearest neighboring staff's own anchors, when that's closer than the default
-    ledger-line margin - capping has to apply per staff (a cluster of anchors at
-    different x-positions/symbols sharing one Y-range), not per individual anchor,
-    since only some of a staff's anchors would otherwise end up adjacent, in sorted
-    order, to the neighboring staff that should cap them.
-
-    Mutates the anchors' .zone in place.
-    """
-    clusters = _cluster_anchors_by_staff(anchors)
-    for i, cluster in enumerate(clusters):
-        cluster_min_y = min(a.min_y for a in cluster)
-        cluster_max_y = max(a.max_y for a in cluster)
-        start_cap = None
-        stop_cap = None
-        if i > 0:
-            previous_max_y = max(a.max_y for a in clusters[i - 1])
-            start_cap = int((previous_max_y + cluster_min_y) / 2)
-        if i < len(clusters) - 1:
-            following_min_y = min(a.min_y for a in clusters[i + 1])
-            stop_cap = int((cluster_max_y + following_min_y) / 2)
-        for anchor in cluster:
-            zone_start = anchor.zone.start
-            zone_stop = anchor.zone.stop
-            if start_cap is not None:
-                zone_start = max(zone_start, start_cap)
-            if stop_cap is not None:
-                zone_stop = min(zone_stop, stop_cap)
-            anchor.zone = range(zone_start, zone_stop)
 
 
 def init_zone(clef_anchors: list[StaffAnchor], image_shape: tuple[int, ...]) -> list[range]:
@@ -864,7 +801,6 @@ def detect_staff(
     )
 
     staff_anchors = filter_unusual_anchors(staff_anchors)
-    cap_anchor_zones_to_neighbors(staff_anchors)
     eprint("Found " + str(len(staff_anchors)) + " staff anchors")
     debug.write_bounding_boxes_alternating_colors("staff_anchors", staff_anchors)
 

--- a/homr/staff_detection.py
+++ b/homr/staff_detection.py
@@ -284,10 +284,37 @@ def connect_staff_lines(
     return connected_lines
 
 
+def _extrapolated_line_y(line: StaffLineSegment, x: float) -> float:
+    fragment = line.get_at(x) or line.staff_fragments[0]
+    return fragment.get_center_extrapolated(x)
+
+
 def are_lines_crossing(lines: list[StaffLineSegment]) -> bool:
+    """
+    Two staff lines cross if their relative vertical order flips somewhere across their
+    shared x-range - checked via each line's own extrapolated y-position (the same
+    extrapolation StaffAnchor and resample_staff_segment already use to place a line at a
+    given x), rather than a literal polygon-overlap test on the underlying fragments.
+
+    A raw polygon test is too sensitive to a single wide fragment with a few degrees of
+    rotation: its far corners can swing several pixels beyond its own center and
+    geometrically touch an adjacent, unrelated staff line's box even though the two lines
+    never actually cross in y (seen on smb/123.png's system 4 bass staff, where this false
+    positive silently discarded an otherwise-valid 5-line anchor).
+    """
     for i in range(len(lines)):
         for j in range(i + 1, len(lines)):
-            if lines[i].is_overlapping(lines[j]):
+            overlap_start = max(lines[i].min_x, lines[j].min_x)
+            overlap_stop = min(lines[i].max_x, lines[j].max_x)
+            if overlap_start >= overlap_stop:
+                continue
+            delta_start = _extrapolated_line_y(lines[i], overlap_start) - _extrapolated_line_y(
+                lines[j], overlap_start
+            )
+            delta_stop = _extrapolated_line_y(lines[i], overlap_stop) - _extrapolated_line_y(
+                lines[j], overlap_stop
+            )
+            if delta_start == 0 or delta_stop == 0 or (delta_start > 0) != (delta_stop > 0):
                 return True
     return False
 
@@ -325,6 +352,59 @@ def begins_or_ends_on_one_staff_line(
         if abs(staff_y - line.center[1]) < unit_size:
             return True
     return False
+
+
+def _extrapolate_missing_staff_line(
+    connected_lines: list[StaffLineSegment],
+    symbol: RotatedBoundingBox,
+    estimated_unit_size: int,
+) -> list[StaffLineSegment] | None:
+    """
+    Segnet's line prediction can miss one of a staff's five lines outright, especially in
+    densely packed multi-staff systems - a real gap in the underlying detection, not a
+    logic bug. If that happens but the other four lines are still evenly spaced at the
+    estimated unit size, synthesize the missing line by extrapolation instead of discarding
+    the whole anchor attempt.
+
+    The anchor symbol (a bar line or clef stem) spans close to the full staff height by
+    construction, so comparing the found lines' own extent against the symbol's own
+    top/bottom tells us which end is short a line, rather than guessing. Returns None
+    (leaving the anchor attempt to fail as before) unless exactly one end shows a
+    unit-size-sized gap and the other end doesn't - anything less clear-cut (e.g. a real
+    3-line pattern, or noise) is left alone rather than guessed at.
+    """
+    if len(connected_lines) != constants.number_of_lines_on_a_staff - 1:
+        return None
+    ordered = sorted(connected_lines, key=lambda line: line.staff_fragments[0].center[1])
+    positions = [line.staff_fragments[0].center[1] for line in ordered]
+    gaps = [positions[i + 1] - positions[i] for i in range(len(positions) - 1)]
+    tolerance = 0.3 * estimated_unit_size
+    if any(abs(gap - estimated_unit_size) > tolerance for gap in gaps):
+        return None
+
+    symbol_top = symbol.center[1] - symbol.size[1] / 2
+    symbol_bottom = symbol.center[1] + symbol.size[1] / 2
+    gap_above = positions[0] - symbol_top
+    gap_below = symbol_bottom - positions[-1]
+    is_missing_above = abs(gap_above - estimated_unit_size) <= tolerance and gap_below <= tolerance
+    is_missing_below = abs(gap_below - estimated_unit_size) <= tolerance and gap_above <= tolerance
+    if is_missing_above == is_missing_below:
+        return None
+
+    reference = ordered[0] if is_missing_above else ordered[-1]
+    offset = -estimated_unit_size if is_missing_above else estimated_unit_size
+    synthesized_fragments = [
+        RotatedBoundingBox(
+            ((fragment.center[0], fragment.center[1] + offset), fragment.box[1], fragment.box[2]),
+            fragment.contours,
+            fragment.debug_id,
+        )
+        for fragment in reference.staff_fragments
+    ]
+    synthesized_line = StaffLineSegment(reference.debug_id, synthesized_fragments)
+    if is_missing_above:
+        return [synthesized_line, *ordered]
+    return [*ordered, synthesized_line]
 
 
 def find_staff_anchors(
@@ -373,6 +453,12 @@ def find_staff_anchors(
                     if (line.max_x - line.min_x)
                     > constants.is_short_connected_line(estimated_unit_size)
                 ]
+            if len(connected_lines) == constants.number_of_lines_on_a_staff - 1:
+                extrapolated = _extrapolate_missing_staff_line(
+                    connected_lines, symbol, estimated_unit_size
+                )
+                if extrapolated is not None:
+                    connected_lines = extrapolated
             if not len(connected_lines) == constants.number_of_lines_on_a_staff:
                 continue
             if not are_lines_parallel(connected_lines, estimated_unit_size):
@@ -527,6 +613,63 @@ def filter_unusual_anchors(anchors: list[StaffAnchor]) -> list[StaffAnchor]:
     return result
 
 
+def _cluster_anchors_by_staff(anchors: list[StaffAnchor]) -> list[list[StaffAnchor]]:
+    """
+    Group anchors whose Y-ranges overlap - i.e. anchors found at different x-positions
+    (or via a clef vs. a bar line) for what is physically the same staff - into one
+    cluster per staff. Anchors are otherwise unordered/unrelated at this point, so this
+    is the only way to tell "these belong to the same staff" from "these are neighbors".
+    """
+    by_y = sorted(anchors, key=lambda a: a.min_y)
+    clusters: list[list[StaffAnchor]] = []
+    cluster_max_y = float("-inf")
+    for anchor in by_y:
+        if clusters and anchor.min_y <= cluster_max_y:
+            clusters[-1].append(anchor)
+        else:
+            clusters.append([anchor])
+        cluster_max_y = max(a.max_y for a in clusters[-1])
+    return clusters
+
+
+def cap_anchor_zones_to_neighbors(anchors: list[StaffAnchor]) -> None:
+    """
+    StaffAnchor.zone extends 5 unit-sizes past the anchor's own staff lines to catch
+    ledger-line notes above/below. In densely packed multi-staff systems (e.g. a choral
+    score with 3+ close staves per system) that extension can reach into a neighboring
+    staff only a few unit-sizes away, pulling its line fragments into this staff's
+    detection in find_raw_staffs_by_connecting_line_fragments and producing a
+    contaminated, oversized RawStaff. Cap every anchor's zone at the midpoint to the
+    nearest neighboring staff's own anchors, when that's closer than the default
+    ledger-line margin - capping has to apply per staff (a cluster of anchors at
+    different x-positions/symbols sharing one Y-range), not per individual anchor,
+    since only some of a staff's anchors would otherwise end up adjacent, in sorted
+    order, to the neighboring staff that should cap them.
+
+    Mutates the anchors' .zone in place.
+    """
+    clusters = _cluster_anchors_by_staff(anchors)
+    for i, cluster in enumerate(clusters):
+        cluster_min_y = min(a.min_y for a in cluster)
+        cluster_max_y = max(a.max_y for a in cluster)
+        start_cap = None
+        stop_cap = None
+        if i > 0:
+            previous_max_y = max(a.max_y for a in clusters[i - 1])
+            start_cap = int((previous_max_y + cluster_min_y) / 2)
+        if i < len(clusters) - 1:
+            following_min_y = min(a.min_y for a in clusters[i + 1])
+            stop_cap = int((cluster_max_y + following_min_y) / 2)
+        for anchor in cluster:
+            zone_start = anchor.zone.start
+            zone_stop = anchor.zone.stop
+            if start_cap is not None:
+                zone_start = max(zone_start, start_cap)
+            if stop_cap is not None:
+                zone_stop = min(zone_stop, stop_cap)
+            anchor.zone = range(zone_start, zone_stop)
+
+
 def init_zone(clef_anchors: list[StaffAnchor], image_shape: tuple[int, ...]) -> list[range]:
     def make_range(start: float, stop: float) -> range:
         return range(max(int(start), 0), min(int(stop), image_shape[1]))
@@ -616,8 +759,16 @@ def find_horizontal_lines(
 
     count = np.insert(count, [0, len(count)], [0, 0])
     norm = (count - np.mean(count)) / np.std(count)
+    # distance is meant to merge anti-aliasing sub-peaks within one line's own thickness into
+    # a single center, not to suppress a neighboring, genuinely distinct staff line - but two
+    # real adjacent staff lines are themselves spaced ~unit_size apart, so passing unit_size
+    # unmodified leaves no margin for the normal +/-1-2px jitter in real scans: a line-to-line
+    # gap that measures a pixel under unit_size gets one of its two real peaks suppressed,
+    # fragmenting a clean 5-line group into incomplete ones. Match the 0.3 * unit_size
+    # tolerance already used for gap validation elsewhere in this file (see
+    # _extrapolate_missing_staff_line) rather than a hard, jitter-intolerant cutoff.
     centers, _ = find_peaks.find_peaks(
-        norm, height=line_threshold, distance=unit_size, prominence=1
+        norm, height=line_threshold, distance=0.7 * unit_size, prominence=1
     )
     centers -= 1
     norm = norm[1:-1]  # Remove prepend / append
@@ -713,6 +864,7 @@ def detect_staff(
     )
 
     staff_anchors = filter_unusual_anchors(staff_anchors)
+    cap_anchor_zones_to_neighbors(staff_anchors)
     eprint("Found " + str(len(staff_anchors)) + " staff anchors")
     debug.write_bounding_boxes_alternating_colors("staff_anchors", staff_anchors)
 

--- a/homr/staff_parsing.py
+++ b/homr/staff_parsing.py
@@ -16,35 +16,112 @@ from homr.transformer.vocabulary import EncodedSymbol, remove_duplicated_symbols
 from homr.type_definitions import NDArray
 
 
-def _have_all_the_same_number_of_staffs(staffs: list[MultiStaff]) -> bool:
-    for staff in staffs:
-        if len(staff.staffs) != len(staffs[0].staffs):
-            return False
-    return True
+def _flatten_staffs(staffs: list[MultiStaff]) -> list[Staff]:
+    return [s for multi_staff in staffs for s in multi_staff.staffs]
 
 
-def _is_close_to_image_top_or_bottom(staff: MultiStaff, image: NDArray) -> bool:
-    tolerance = 50.0
-    closest_distance_to_top_or_bottom: list[float] = [
-        min(s.min_x, image.shape[0] - s.max_x) for s in staff.staffs
-    ]
-    return min(closest_distance_to_top_or_bottom) < tolerance
+def _regroup_by_period(
+    flat_staffs: list[Staff], period: int, front_trim: int, back_trim: int
+) -> list[MultiStaff]:
+    core = flat_staffs[front_trim : len(flat_staffs) - back_trim]
+    return [MultiStaff(core[i : i + period], []) for i in range(0, len(core), period)]
 
 
-def _ensure_same_number_of_staffs(staffs: list[MultiStaff], image: NDArray) -> list[MultiStaff]:
-    if _have_all_the_same_number_of_staffs(staffs):
+def _find_periodic_core(flat_staffs: list[Staff]) -> tuple[int, int, int] | None:
+    """
+    Find a repeating sequence of staff layouts among individual staffs, e.g.
+    a solo staff followed by a piano grand staff (2 staffs), repeated for
+    every system in a vocal score with piano accompaniment.
+
+    We work on the flattened sequence of raw staffs rather than on the
+    MultiStaff rows produced upstream, because that upstream grouping is
+    itself only a heuristic (staffs sharing a bar line or clef get merged
+    into one row) and can be inconsistent across a page: the same kind of
+    solo-staff-plus-grand-staff pair might end up pre-merged into one row for
+    one system and left as two separate rows for another, purely because of
+    how cleanly a bar line lined up. Searching row-by-row would then see two
+    different "shapes" for what is structurally the same repeating pattern.
+    Working on individual staffs sidesteps that inconsistency entirely.
+
+    A system right at the start or end of the page can break the pattern on
+    its own without invalidating it: an introduction or coda system with a
+    genuinely different layout, or simply the most poorly detected staff on
+    the page. We therefore allow trimming up to one period's worth of staffs
+    from either edge before requiring the remainder to tile exactly. We
+    never trim from the middle of the page: a mismatch there is a detection
+    problem to fix upstream, not something to paper over here.
+
+    Returns (period, front_trim, back_trim) for the smallest total trim and,
+    among ties, the smallest period -- so an already-uniform page (period 1,
+    no trim) is always preferred when it fits, and we never discard more of
+    the page than necessary. Returns None if no repeating core of at least
+    two full cycles can be found.
+    """
+    layout = [s.is_grandstaff for s in flat_staffs]
+    n = len(layout)
+    best: tuple[int, int, int, int] | None = None
+    for period in range(1, n // 2 + 1):
+        for front_trim in range(period + 1):
+            for back_trim in range(period + 1):
+                core = layout[front_trim : n - back_trim]
+                if len(core) < 2 * period or len(core) % period != 0:
+                    continue
+                rows = [tuple(core[i : i + period]) for i in range(0, len(core), period)]
+                if not all(row == rows[0] for row in rows):
+                    continue
+                candidate = (front_trim + back_trim, period, front_trim, back_trim)
+                if best is None or candidate[:2] < best[:2]:
+                    best = candidate
+    if best is None:
+        return None
+    _, period, front_trim, back_trim = best
+    return period, front_trim, back_trim
+
+
+def _ensure_same_number_of_staffs(staffs: list[MultiStaff]) -> list[MultiStaff]:
+    """
+    If every system already has the same number of *more than one* staff, trust that
+    directly rather than re-deriving it via _find_periodic_core. That function's signature
+    is each flat staff's is_grandstaff flag, which is a fine way to tell "solo staff" from
+    "piano grand staff" apart when the two are pre-merged inconsistently across the page
+    (see its own docstring) - but it carries zero information when a page has N genuinely
+    independent, same-type staffs per system and none of them are a grand staff (e.g. a
+    string quartet): the flattened signature is then a constant sequence, which trivially -
+    and wrongly - satisfies period=1, collapsing all N voices into one. Checking uniformity
+    upfront on the untouched, already-correct per-system grouping sidesteps that degenerate
+    case entirely.
+
+    Restricted to row length > 1: a page where every row is already a single raw staff
+    (nothing grouped yet, e.g. a solo-plus-piano page where no bar line happened to
+    pre-merge any pair) is *also* uniform by this same measure, but there _find_periodic_
+    core is exactly what's needed to discover the real, larger repeating pattern from
+    scratch - that's the case this function was originally written for, and it is never
+    already uniform at a row length above 1.
+    """
+    row_lengths = {len(multi_staff.staffs) for multi_staff in staffs}
+    if len(row_lengths) == 1 and next(iter(row_lengths)) > 1:
         return staffs
-    if len(staffs) > 2:
-        if _is_close_to_image_top_or_bottom(
-            staffs[0], image
-        ) and _have_all_the_same_number_of_staffs(staffs[1:]):
-            eprint("Removing first system from all voices, as it has a different number of staffs")
-            return staffs[1:]
-        if _is_close_to_image_top_or_bottom(
-            staffs[-1], image
-        ) and _have_all_the_same_number_of_staffs(staffs[:-1]):
-            eprint("Removing last system from all voices, as it has a different number of staffs")
-            return staffs[:-1]
+    flat_staffs = _flatten_staffs(staffs)
+    core = _find_periodic_core(flat_staffs)
+    if core is not None:
+        period, front_trim, back_trim = core
+        if front_trim > 0:
+            eprint(
+                f"Removing the first {front_trim} staff(s), as they don't fit "
+                "the staff layout the rest of the page repeats"
+            )
+        if back_trim > 0:
+            eprint(
+                f"Removing the last {back_trim} staff(s), as they don't fit "
+                "the staff layout the rest of the page repeats"
+            )
+        if period > 1:
+            eprint(
+                "Systems repeat every",
+                period,
+                "staffs with a different layout each time, combining them into one row",
+            )
+        return _regroup_by_period(flat_staffs, period, front_trim, back_trim)
     result: list[MultiStaff] = []
     for staff in staffs:
         result.extend(staff.break_apart())
@@ -263,7 +340,7 @@ def parse_staffs(
     Dewarps each staff and then runs it through an algorithm which extracts
     the rhythm and pitch information.
     """
-    staffs = _ensure_same_number_of_staffs(staffs, image)
+    staffs = _ensure_same_number_of_staffs(staffs)
     # For simplicity we call every staff in a multi staff a voice,
     # even if it's part of a grand staff.
     number_of_voices = _get_number_of_voices(staffs)

--- a/tests/test_ned_score.py
+++ b/tests/test_ned_score.py
@@ -1,7 +1,12 @@
 import unittest
 import xml.etree.ElementTree as ET
 
-from validation.ned_score import _split_grand_staff
+from homr.transformer.vocabulary import EncodedSymbol
+from validation.ned_score import _align_parts, _ned_from_parts, _split_grand_staff
+
+
+def _sym(rhythm: str) -> EncodedSymbol:
+    return EncodedSymbol(rhythm)
 
 _GRAND_STAFF_PART = """
   <part id="P1">
@@ -85,3 +90,41 @@ class TestSplitGrandStaff(unittest.TestCase):
 
     def test_invalid_xml_returns_input_unchanged(self) -> None:
         self.assertEqual("not xml", _split_grand_staff("not xml"))
+
+
+class TestAlignParts(unittest.TestCase):
+    def test_reorders_reversed_parts_by_content(self) -> None:
+        # kern lists [bass, treble] but the tool's split-grand-staff output
+        # lists [treble, bass] for the same piece - the exact reversal found
+        # in polish-scores samples like 43 and 52 (see memory).
+        bass = [_sym("note_4"), _sym("note_8"), _sym("note_4")]
+        treble = [_sym("note_8"), _sym("note_16"), _sym("note_16"), _sym("note_4")]
+        kern_parts = [bass, treble]
+        xml_parts = [treble, bass]
+
+        aligned_kern, aligned_xml = _align_parts(kern_parts, xml_parts)
+
+        self.assertEqual(aligned_kern, [bass, treble])
+        self.assertEqual(aligned_xml, [bass, treble])
+
+    def test_already_aligned_parts_are_unchanged(self) -> None:
+        part_a = [_sym("note_4"), _sym("note_8")]
+        part_b = [_sym("note_16"), _sym("note_4"), _sym("note_4")]
+
+        aligned_kern, aligned_xml = _align_parts([part_a, part_b], [part_a, part_b])
+
+        self.assertEqual(aligned_kern, [part_a, part_b])
+        self.assertEqual(aligned_xml, [part_a, part_b])
+
+    def test_ned_from_parts_ignores_part_order(self) -> None:
+        # Same content as test_reorders_reversed_parts_by_content: a perfect,
+        # zero-distance match once parts are correctly paired up. Before the
+        # fix, comparing positionally (kern's bass against the tool's treble)
+        # would have produced a large, spurious NED for identical content.
+        bass = [_sym("note_4"), _sym("note_8"), _sym("note_4")]
+        treble = [_sym("note_8"), _sym("note_16"), _sym("note_16"), _sym("note_4")]
+
+        result = _ned_from_parts([bass, treble], [treble, bass])
+
+        self.assertEqual(0, result.distance)
+        self.assertEqual(0.0, result.ned)

--- a/tests/test_ned_score.py
+++ b/tests/test_ned_score.py
@@ -2,7 +2,14 @@ import unittest
 import xml.etree.ElementTree as ET
 
 from homr.transformer.vocabulary import EncodedSymbol
-from validation.ned_score import _align_parts, _ned_from_parts, _split_grand_staff
+from validation.ned_score import (
+    _align_parts,
+    _ned_from_parts,
+    _split_grand_staff,
+    _strip_articulation_from_parts,
+    _without_unreliable_articulation,
+    compute_ned,
+)
 
 
 def _sym(rhythm: str) -> EncodedSymbol:
@@ -129,3 +136,60 @@ class TestAlignParts(unittest.TestCase):
 
         self.assertEqual(0, result.distance)
         self.assertEqual(0.0, result.ned)
+
+
+class TestUnreliableArticulation(unittest.TestCase):
+    def test_removes_only_unreliable_components(self) -> None:
+        self.assertEqual(_without_unreliable_articulation("staccato"), "_")
+        self.assertEqual(_without_unreliable_articulation("staccatissimo"), "_")
+        self.assertEqual(_without_unreliable_articulation("turn"), "_")
+        self.assertEqual(_without_unreliable_articulation("staccatissimo_staccato"), "_")
+
+    def test_keeps_reliable_components_of_compound_values(self) -> None:
+        self.assertEqual(_without_unreliable_articulation("accent_staccato"), "accent")
+        self.assertEqual(_without_unreliable_articulation("fermata_turn"), "fermata")
+        self.assertEqual(
+            _without_unreliable_articulation("accent_staccato_tenuto"), "accent_tenuto"
+        )
+
+    def test_leaves_reliable_only_values_unchanged(self) -> None:
+        self.assertEqual(_without_unreliable_articulation("accent"), "accent")
+
+    def test_passes_through_nonote_and_empty(self) -> None:
+        self.assertEqual(_without_unreliable_articulation("."), ".")
+        self.assertEqual(_without_unreliable_articulation("_"), "_")
+
+    def test_strip_articulation_from_parts_clears_only_unreliable_symbols(self) -> None:
+        part = [
+            EncodedSymbol("note_4", "C5", articulation="staccato"),
+            EncodedSymbol("note_4", "D5", articulation="accent"),
+            EncodedSymbol("note_4", "E5", articulation="accent_staccato"),
+        ]
+
+        result = _strip_articulation_from_parts([part])
+
+        self.assertEqual(
+            [s.articulation for s in result[0]],
+            ["_", "accent", "accent"],
+        )
+        # Original symbols must not be mutated - only copies are edited.
+        self.assertEqual(part[0].articulation, "staccato")
+
+    def test_compute_ned_ignores_staccato_mismatch_when_flag_set(self) -> None:
+        kern = "**kern\n4c\n4d\n4e\n*-\n"
+        pred = "**kern\n4c'\n4d\n4e'\n*-\n"
+
+        without_flag = compute_ned(kern, pred)
+        with_flag = compute_ned(kern, pred, ignore_unreliable_articulation=True)
+
+        self.assertGreater(without_flag.articulation_ned, 0.0)
+        self.assertEqual(with_flag.articulation_ned, 0.0)
+        self.assertEqual(with_flag.ned, 0.0)
+
+    def test_compute_ned_still_scores_accent_mismatch_when_flag_set(self) -> None:
+        kern = "**kern\n4c\n4d^\n4e\n*-\n"
+        pred = "**kern\n4c\n4d\n4e\n*-\n"
+
+        with_flag = compute_ned(kern, pred, ignore_unreliable_articulation=True)
+
+        self.assertGreater(with_flag.articulation_ned, 0.0)

--- a/tests/test_ned_score.py
+++ b/tests/test_ned_score.py
@@ -8,6 +8,7 @@ from validation.ned_score import _align_parts, _ned_from_parts, _split_grand_sta
 def _sym(rhythm: str) -> EncodedSymbol:
     return EncodedSymbol(rhythm)
 
+
 _GRAND_STAFF_PART = """
   <part id="P1">
     <measure number="1">

--- a/tests/test_ned_score.py
+++ b/tests/test_ned_score.py
@@ -1,0 +1,87 @@
+import unittest
+import xml.etree.ElementTree as ET
+
+from validation.ned_score import _split_grand_staff
+
+_GRAND_STAFF_PART = """
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <staves>2</staves>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+        <clef number="2"><sign>F</sign><line>4</line></clef>
+      </attributes>
+      <note><pitch><step>C</step><octave>5</octave></pitch>
+        <duration>1</duration><type>quarter</type><voice>1</voice><staff>1</staff></note>
+      <note><pitch><step>C</step><octave>3</octave></pitch>
+        <duration>1</duration><type>quarter</type><voice>2</voice><staff>2</staff></note>
+    </measure>
+  </part>
+"""
+
+_VOICE_PART = """
+  <part id="P0">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><pitch><step>E</step><octave>5</octave></pitch>
+        <duration>1</duration><type>quarter</type><voice>1</voice><staff>1</staff></note>
+    </measure>
+  </part>
+"""
+
+
+def _wrap(parts_xml: str) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list><score-part id="P0" /><score-part id="P1" /></part-list>
+  {parts_xml}
+</score-partwise>"""
+
+
+class TestSplitGrandStaff(unittest.TestCase):
+    def test_lone_grand_staff_part_still_splits(self) -> None:
+        xml_text = _wrap(_GRAND_STAFF_PART)
+
+        result = _split_grand_staff(xml_text)
+
+        root = ET.fromstring(result)  # noqa: S314
+        parts = root.findall("part")
+        self.assertEqual(2, len(parts))
+        self.assertEqual(1, len(parts[0].findall(".//note")))
+        self.assertEqual(1, len(parts[1].findall(".//note")))
+        part_ids = {p.get("id") for p in parts}
+        score_part_ids = {sp.get("id") for sp in root.findall(".//score-part")}
+        self.assertEqual(part_ids, score_part_ids)
+
+    def test_grand_staff_alongside_other_part_also_splits(self) -> None:
+        # A solo voice part plus a piano grand staff: two <part> elements in
+        # the document, only one of which has <staves>2</staves>. This used
+        # to be left untouched because the old check required exactly one
+        # <part> in the whole document.
+        xml_text = _wrap(_VOICE_PART + _GRAND_STAFF_PART)
+
+        result = _split_grand_staff(xml_text)
+
+        root = ET.fromstring(result)  # noqa: S314
+        parts = root.findall("part")
+        self.assertEqual(3, len(parts))
+        note_counts = [len(p.findall(".//note")) for p in parts]
+        self.assertEqual([1, 1, 1], note_counts)
+        part_ids = [p.get("id") for p in parts]
+        self.assertEqual(len(part_ids), len(set(part_ids)))
+        score_part_ids = {sp.get("id") for sp in root.findall(".//score-part")}
+        self.assertEqual(set(part_ids), score_part_ids)
+
+    def test_no_grand_staff_returns_input_unchanged(self) -> None:
+        xml_text = _wrap(_VOICE_PART)
+
+        result = _split_grand_staff(xml_text)
+
+        self.assertEqual(xml_text, result)
+
+    def test_invalid_xml_returns_input_unchanged(self) -> None:
+        self.assertEqual("not xml", _split_grand_staff("not xml"))

--- a/tests/test_staff_parsing.py
+++ b/tests/test_staff_parsing.py
@@ -1,0 +1,110 @@
+import unittest
+
+from homr.model import MultiStaff, Staff, StaffPoint
+from homr.staff_parsing import _ensure_same_number_of_staffs, _get_number_of_voices
+
+
+def make_staff(number: int, is_grandstaff: bool = False) -> Staff:
+    y_points = [10 * i + 100 * float(number) for i in range(5)]
+    staff = Staff([StaffPoint(0.0, y_points, 0)])
+    staff.is_grandstaff = is_grandstaff
+    return staff
+
+
+def make_row(number: int, is_grandstaff: bool = False) -> MultiStaff:
+    return MultiStaff([make_staff(number, is_grandstaff)], [])
+
+
+def _layouts(result: list[MultiStaff]) -> list[list[bool]]:
+    return [[s.is_grandstaff for s in row.staffs] for row in result]
+
+
+class TestStaffParsing(unittest.TestCase):
+    def test_ensure_same_number_of_staffs_already_uniform(self) -> None:
+        staffs = [make_row(i, is_grandstaff=True) for i in range(4)]
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[True]] * 4, _layouts(result))
+        self.assertEqual(1, _get_number_of_voices(result))
+
+    def test_ensure_same_number_of_staffs_merges_repeating_pattern(self) -> None:
+        # A solo staff followed by a piano grand staff, repeated for every system,
+        # as in a vocal score with piano accompaniment.
+        staffs = []
+        for i in range(0, 12, 3):
+            staffs.append(make_row(i))
+            staffs.append(make_row(i + 1, is_grandstaff=True))
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[False, True]] * 4, _layouts(result))
+        self.assertEqual(2, _get_number_of_voices(result))
+
+    def test_ensure_same_number_of_staffs_merges_repeating_pattern_grand_staff_first(self) -> None:
+        # Same pattern, but the piano grand staff comes first in every system
+        # instead of the solo staff, e.g. an instrumental introduction before
+        # the voice enters for the rest of the piece.
+        staffs = []
+        for i in range(0, 12, 3):
+            staffs.append(make_row(i, is_grandstaff=True))
+            staffs.append(make_row(i + 1))
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[True, False]] * 4, _layouts(result))
+
+    def test_ensure_same_number_of_staffs_absorbs_inconsistently_pre_merged_row(self) -> None:
+        # A solo-staff-plus-grand-staff pair that an earlier detection step
+        # (staffs sharing a bar line) happened to merge into one row, while
+        # the same kind of pair elsewhere on the page stayed as two separate
+        # rows -- purely because of how cleanly a bar line lined up, not
+        # because the underlying layout differs. The pre-merged row must be
+        # recognized as fitting the repeating pattern, not trimmed away as an
+        # outlier just because its row shape looks different from the rest.
+        pre_merged = MultiStaff([make_staff(0), make_staff(1, is_grandstaff=True)], [])
+        staffs = [pre_merged]
+        for i in range(2, 8, 2):
+            staffs.append(make_row(i))
+            staffs.append(make_row(i + 1, is_grandstaff=True))
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[False, True]] * 4, _layouts(result))
+
+    def test_ensure_same_number_of_staffs_drops_leading_outlier(self) -> None:
+        # A single system at the very top that doesn't match the otherwise
+        # fully uniform rest of the page (e.g. the worst-detected staff).
+        staffs = [make_row(0)] + [make_row(i, is_grandstaff=True) for i in range(1, 5)]
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[True]] * 4, _layouts(result))
+
+    def test_ensure_same_number_of_staffs_drops_trailing_outlier(self) -> None:
+        staffs = [make_row(i, is_grandstaff=True) for i in range(4)] + [make_row(4)]
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual([[True]] * 4, _layouts(result))
+
+    def test_ensure_same_number_of_staffs_falls_back_to_break_apart(self) -> None:
+        # No consistent per-system layout and no clean repeating pattern at
+        # any period/trim: the only safe option left is to treat every raw
+        # staff as its own system, including exploding rows that an earlier
+        # step had bundled together.
+        staffs = [
+            MultiStaff([make_staff(0), make_staff(1, is_grandstaff=True)], []),
+            MultiStaff([make_staff(2, is_grandstaff=True)], []),
+            MultiStaff([make_staff(3), make_staff(4)], []),
+            MultiStaff([make_staff(5)], []),
+            MultiStaff([make_staff(6, is_grandstaff=True)], []),
+        ]
+
+        result = _ensure_same_number_of_staffs(staffs)
+
+        self.assertEqual(
+            [[False], [True], [True], [False], [False], [False], [True]], _layouts(result)
+        )
+        for row in result:
+            self.assertEqual(1, len(row.staffs))

--- a/training/omr_datasets/humdrum_kern_parser.py
+++ b/training/omr_datasets/humdrum_kern_parser.py
@@ -1,4 +1,6 @@
+import copy
 import re
+from typing import NamedTuple
 
 from homr.circle_of_fifths import strip_naturals
 from homr.transformer.vocabulary import EncodedSymbol, empty, nonote
@@ -9,10 +11,26 @@ from training.omr_datasets.staff_merging import (
 from training.transformer.training_vocabulary import VocabularyStats, check_token_lines
 
 
+class _SignatureState(NamedTuple):
+    """The clef/key/time signature in force at the end of a staff's kern document.
+
+    Carried across concatenated multi-document kern (one document per system) so a
+    system's opening clef/key/time is only emitted as a token when it actually differs
+    from what was already in force - not just because the document restarts.
+    """
+
+    clef: EncodedSymbol
+    key: EncodedSymbol
+    time: EncodedSymbol
+
+
 def convert_kern_to_tokens(lines: list[str]) -> list[EncodedSymbol]:
     staffs = _merge_multiple_voices_on_the_same_staff(lines)
     merged = merge_upper_and_lower_staff(
-        [_convert_single_staff(staff_no, staff) for staff_no, staff in enumerate(reversed(staffs))]
+        [
+            _convert_single_staff(staff_no, staff)[0]
+            for staff_no, staff in enumerate(reversed(staffs))
+        ]
     )
     merged = _remove_redundant_key_changes(merged)
     merged = _fix_final_repeat_start(merged)
@@ -29,17 +47,26 @@ def convert_kern_to_parts(lines: list[str]) -> list[list[EncodedSymbol]]:
     also preserves in its XML output.
 
     Handles concatenated multi-document kern (multiple **kern...*- sections, as
-    produced by datasets that store one kern document per staff system) by
-    parsing each document separately and extending the corresponding parts.
+    produced by datasets that store one kern document per staff system) by parsing
+    each document separately and extending the corresponding parts. The clef/key/time
+    signature in force is carried from one document to the next, so a system's opening
+    declarations only become tokens when they are an actual change - not just because
+    every system re-prints them (see _SignatureState).
     """
     docs = _split_kern_documents(lines)
     if len(docs) == 1:
-        return _parse_kern_document(docs[0])
+        parts, _carry = _parse_kern_document(docs[0])
+        return parts
 
-    all_parts = [_parse_kern_document(doc) for doc in docs]
-    n_parts = max(len(p) for p in all_parts)
+    carry: list[_SignatureState] | None = None
+    doc_parts_list: list[list[list[EncodedSymbol]]] = []
+    for doc in docs:
+        parts, carry = _parse_kern_document(doc, carry)
+        doc_parts_list.append(parts)
+
+    n_parts = max(len(p) for p in doc_parts_list)
     merged: list[list[EncodedSymbol]] = [[] for _ in range(n_parts)]
-    for doc_parts in all_parts:
+    for doc_parts in doc_parts_list:
         for i, part in enumerate(doc_parts):
             merged[i].extend(part)
     return merged
@@ -60,18 +87,23 @@ def _split_kern_documents(lines: list[str]) -> list[list[str]]:
     return docs or [lines]
 
 
-def _parse_kern_document(lines: list[str]) -> list[list[EncodedSymbol]]:
+def _parse_kern_document(
+    lines: list[str], carry: list[_SignatureState] | None = None
+) -> tuple[list[list[EncodedSymbol]], list[_SignatureState]]:
     staffs = _merge_multiple_voices_on_the_same_staff(lines)
     ordered = list(reversed(staffs)) if len(staffs) == 2 else staffs
     result = []
+    new_carry: list[_SignatureState] = []
     for staff_no, staff in enumerate(ordered):
-        single = _convert_single_staff(staff_no, staff)
+        initial = carry[staff_no] if carry is not None and staff_no < len(carry) else None
+        single, final_state = _convert_single_staff(staff_no, staff, initial)
         part = merge_upper_and_lower_staff([single])
         part = _remove_redundant_key_changes(part)
         part = _fix_final_repeat_start(part)
         part = strip_naturals(part)
         result.append(part)
-    return result
+        new_carry.append(final_state)
+    return result, new_carry
 
 
 def _merge_multiple_voices_on_the_same_staff(
@@ -171,9 +203,11 @@ def _fix_final_repeat_start(symbols: list[EncodedSymbol]) -> list[EncodedSymbol]
     return symbols
 
 
-def _convert_single_staff(staff_no: int, lines: list[str]) -> list[EncodedSymbolWithPos]:
+def _convert_single_staff(
+    staff_no: int, lines: list[str], initial: _SignatureState | None = None
+) -> tuple[list[EncodedSymbolWithPos], _SignatureState]:
     converter = HumdrumKernConverter()
-    return converter.convert_humdrum_kern(staff_no, lines)
+    return converter.convert_humdrum_kern(staff_no, lines, initial)
 
 
 class HumdrumKernConverter:
@@ -357,13 +391,17 @@ class HumdrumKernConverter:
         return result
 
     def convert_humdrum_kern(
-        self, staff_no: int, lines: list[str]
-    ) -> list[EncodedSymbolWithPos]:  # noqa: C901
+        self, staff_no: int, lines: list[str], initial: _SignatureState | None = None
+    ) -> tuple[list[EncodedSymbolWithPos], _SignatureState]:  # noqa: C901
         result: list[EncodedSymbolWithPos] = []
 
-        clef = EncodedSymbolWithPos(-10, self._get_default_clef(staff_no))
-        keySignature = EncodedSymbolWithPos(-9, EncodedSymbol("keySignature_0"))
-        timeSignature = EncodedSymbolWithPos(-8, EncodedSymbol("timeSignature/4"))
+        prev_clef = initial.clef if initial is not None else self._get_default_clef(staff_no)
+        prev_key = initial.key if initial is not None else EncodedSymbol("keySignature_0")
+        prev_time = initial.time if initial is not None else EncodedSymbol("timeSignature/4")
+
+        clef = EncodedSymbolWithPos(-10, prev_clef)
+        keySignature = EncodedSymbolWithPos(-9, prev_key)
+        timeSignature = EncodedSymbolWithPos(-8, prev_time)
         initial_signature_was_added = False
         for line_no, line in self._add_line_numbers(lines):
             if line.startswith("="):
@@ -371,27 +409,39 @@ class HumdrumKernConverter:
                     parsed = self.parse_barline(line)
                     result.extend([EncodedSymbolWithPos(line_no, p) for p in parsed])
             elif line.startswith("*k"):
-                keySignature = EncodedSymbolWithPos(-9, self.parse_key_signature(line))
-                if initial_signature_was_added:
-                    result.append(EncodedSymbolWithPos(line_no, keySignature.symbol))
+                new_key = self.parse_key_signature(line)
+                if initial_signature_was_added and new_key != keySignature.symbol:
+                    result.append(EncodedSymbolWithPos(line_no, new_key))
+                keySignature = EncodedSymbolWithPos(-9, new_key)
             elif line.startswith("*M"):
-                timeSignature = EncodedSymbolWithPos(-8, self.parse_time_signature(line))
-                if initial_signature_was_added:
-                    result.append(EncodedSymbolWithPos(line_no, timeSignature.symbol))
+                new_time = self.parse_time_signature(line)
+                if initial_signature_was_added and new_time != timeSignature.symbol:
+                    result.append(EncodedSymbolWithPos(line_no, new_time))
+                timeSignature = EncodedSymbolWithPos(-8, new_time)
             elif line.startswith("*clef"):
-                clef = EncodedSymbolWithPos(-10, self.parse_clef(line))
-                if initial_signature_was_added:
-                    result.append(EncodedSymbolWithPos(line_no, clef.symbol))
+                new_clef = self.parse_clef(line)
+                if initial_signature_was_added and new_clef != clef.symbol:
+                    result.append(EncodedSymbolWithPos(line_no, new_clef))
+                clef = EncodedSymbolWithPos(-10, new_clef)
             elif line.startswith("*"):
                 # All other control instructions can be ignored
                 pass
             else:
                 if not initial_signature_was_added:
                     # Symbols can be appear in various order
-                    # and duplicated (in which the latest wins)
-                    result.append(clef)
-                    result.append(keySignature)
-                    result.append(timeSignature)
+                    # and duplicated (in which the latest wins). With no carried-over
+                    # state (the very first document of a piece), always emit - that is
+                    # the real start of the piece, regardless of whether it happens to
+                    # match our internal defaults. With carried-over state (a later
+                    # system in a multi-document kern file, see _SignatureState), only
+                    # emit if it actually changed - a system restart re-declaring the
+                    # same clef/key/time is not a real change.
+                    if initial is None or clef.symbol != prev_clef:
+                        result.append(clef)
+                    if initial is None or keySignature.symbol != prev_key:
+                        result.append(keySignature)
+                    if initial is None or timeSignature.symbol != prev_time:
+                        result.append(timeSignature)
                     initial_signature_was_added = True
                 symbols = line.split()
                 chord_dur = "4"
@@ -408,7 +458,12 @@ class HumdrumKernConverter:
                         EncodedSymbolWithPos(line_no, self.parse_note_or_rest(token, chord_dur))
                     )
 
-        return result
+        # Snapshot independent copies: the symbols above are later mutated in place
+        # (e.g. merge_upper_and_lower_staff fills in symbol.position), so returning the
+        # same objects would let that later mutation leak back into the carried state.
+        return result, _SignatureState(
+            copy.copy(clef.symbol), copy.copy(keySignature.symbol), copy.copy(timeSignature.symbol)
+        )
 
 
 if __name__ == "__main__":

--- a/validation/ned_benchmark.py
+++ b/validation/ned_benchmark.py
@@ -100,15 +100,20 @@ def _record_success(
     db: BenchmarkDB | None,
     kern_parser: str = "native",
     xml_parser: str = "native",
+    ignore_unreliable_articulation: bool = False,
 ) -> None:
     kern_parts: list[list[EncodedSymbol]] = []
     xml_parts: list[list[EncodedSymbol]] = []
     if xml_parser == "musicdiff":
-        result = _musicdiff_ned_for_sample(kern_text, raw_output)
+        result = _musicdiff_ned_for_sample(kern_text, raw_output, ignore_unreliable_articulation)
     elif xml_parser == "musicdiff_detailed":
-        result = _musicdiff_detailed_ned_for_sample(kern_text, raw_output)
+        result = _musicdiff_detailed_ned_for_sample(
+            kern_text, raw_output, ignore_unreliable_articulation
+        )
     else:
-        kern_parts, xml_parts = _parse_output(kern_text, raw_output, kern_parser, xml_parser)
+        kern_parts, xml_parts = _parse_output(
+            kern_text, raw_output, kern_parser, xml_parser, ignore_unreliable_articulation
+        )
         result = _ned_from_parts(kern_parts, xml_parts)
     results.append(result)
     print(  # noqa: T201
@@ -153,6 +158,7 @@ def update_ned_scores(
     kern_parser: str = "native",
     xml_parser: str = "native",
     limit: int | None = None,
+    ignore_unreliable_articulation: bool = False,
 ) -> None:
     """Recompute NED for all samples with stored actual_text using the current parsers.
 
@@ -180,14 +186,18 @@ def update_ned_scores(
     for sample_id, kern_text, actual_text in rows:
         try:
             if xml_parser == "musicdiff":
-                result = _musicdiff_ned_for_sample(kern_text, actual_text)
+                result = _musicdiff_ned_for_sample(
+                    kern_text, actual_text, ignore_unreliable_articulation
+                )
                 events: list[TokenEvent] = []
             elif xml_parser == "musicdiff_detailed":
-                result = _musicdiff_detailed_ned_for_sample(kern_text, actual_text)
+                result = _musicdiff_detailed_ned_for_sample(
+                    kern_text, actual_text, ignore_unreliable_articulation
+                )
                 events = []
             else:
                 kern_parts, xml_parts = _parse_output(
-                    kern_text, actual_text, kern_parser, xml_parser
+                    kern_text, actual_text, kern_parser, xml_parser, ignore_unreliable_articulation
                 )
                 result = _ned_from_parts(kern_parts, xml_parts)
                 events = _events_for_parts(kern_parts, xml_parts)
@@ -249,6 +259,7 @@ def run_benchmark(
     batch_size: int = 10,
     kern_parser: str = "native",
     xml_parser: str = "native",
+    ignore_unreliable_articulation: bool = False,
 ) -> None:
     """
     Wire data source, tool, and check together.
@@ -262,6 +273,8 @@ def run_benchmark(
     output_db:    path to a SQLite file; written fresh by default, or appended with continue_run
     continue_run: if True, skip sample_ids already present in output_db
     batch_size:   number of samples per batch_run() call (default 10)
+    ignore_unreliable_articulation: see ned_score.py's "Known ground-truth reliability
+                  exceptions" - only ever set True by validation/polish-scores.py.
     """
     db: BenchmarkDB | None = None
     skip_ids: set[str] = set()
@@ -316,6 +329,7 @@ def run_benchmark(
                                 db,
                                 kern_parser,
                                 xml_parser,
+                                ignore_unreliable_articulation,
                             )
                     except Exception as e:  # noqa: BLE001
                         _record_failure(
@@ -337,7 +351,14 @@ def run_benchmark(
                 with _sample_timeout():
                     raw_output = tool(kern_text, image)
                     _record_success(
-                        sample_id, kern_text, raw_output, results, db, kern_parser, xml_parser
+                        sample_id,
+                        kern_text,
+                        raw_output,
+                        results,
+                        db,
+                        kern_parser,
+                        xml_parser,
+                        ignore_unreliable_articulation,
                     )
             except Exception as e:  # noqa: BLE001
                 _record_failure(

--- a/validation/ned_score.py
+++ b/validation/ned_score.py
@@ -73,27 +73,17 @@ def _component_dist(a: list[EncodedSymbol], b: list[EncodedSymbol], field: str) 
     return editdistance.eval([getattr(s, field) for s in a], [getattr(s, field) for s in b])
 
 
-def _split_grand_staff(xml_text: str) -> str:
+def _split_grand_staff_part(part: ET.Element) -> list[ET.Element]:
     """
-    Convert a single grand-staff <Part> into two separate <Part> elements.
-
-    Tools like homr output piano music as one <Part> with <staves>2</staves> and each
-    note tagged <staff>1</staff> or <staff>2</staff>.  music_xml_file_to_tokens treats
-    this as a single voice, so all notes land in xml_upper and xml_lower is empty,
-    inflating NED massively.  This function detects that pattern and splits the part
-    before tokenisation so the staves are compared independently.
+    Split a single <part> with <staves>2</staves> into two single-staff <part>
+    elements. Returns [part] unchanged if it isn't a 2-staff grand staff (this
+    also covers the (currently unseen) 3+-staff case: splitting would silently
+    drop any staff beyond the second, so we leave those parts alone rather
+    than guess).
     """
-    try:
-        root = ET.fromstring(xml_text)  # noqa: S314
-    except ET.ParseError:
-        return xml_text
-
-    parts = root.findall("part")
-    if len(parts) != 1:
-        return xml_text
-    staves_el = parts[0].find(".//staves")
-    if staves_el is None or int(staves_el.text or "1") < 2:
-        return xml_text
+    staves_el = part.find(".//staves")
+    if staves_el is None or int(staves_el.text or "1") != 2:
+        return [part]
 
     def _staff_num(el: ET.Element) -> int:
         s = el.find("staff")
@@ -101,7 +91,7 @@ def _split_grand_staff(xml_text: str) -> str:
 
     # Build two lists of measure elements, one per staff.
     split: list[list[ET.Element]] = [[], []]
-    for measure in parts[0].findall("measure"):
+    for measure in part.findall("measure"):
         for idx in range(2):
             split[idx].append(ET.Element("measure", measure.attrib))
 
@@ -149,21 +139,52 @@ def _split_grand_staff(xml_text: str) -> str:
             split[0][-1].append(child)
             split[1][-1].append(copy.deepcopy(child))
 
-    # Reconstruct the score with two parts.
-    new_root = ET.Element(root.tag, root.attrib)
-    for child in root:
-        if child.tag == "part-list":
-            pl = ET.SubElement(new_root, "part-list")
-            for pid in ("P1", "P2"):
-                sp = ET.SubElement(pl, "score-part", id=pid)
-                ET.SubElement(sp, "part-name").text = pid
-        elif child.tag != "part":
-            new_root.append(copy.deepcopy(child))
-
-    for idx, measures in enumerate(split):
-        p = ET.SubElement(new_root, "part", id=f"P{idx + 1}")
+    result = []
+    for measures in split:
+        p = ET.Element("part")
         for m in measures:
             p.append(m)
+        result.append(p)
+    return result
+
+
+def _split_grand_staff(xml_text: str) -> str:
+    """
+    Split every <part> that has <staves>2</staves> into two single-staff
+    <part> elements, in place, keeping the relative order of the other parts.
+
+    Tools like homr output a piano grand staff as one <Part> with
+    <staves>2</staves> and each note tagged <staff>1</staff> or
+    <staff>2</staff>. music_xml_file_to_tokens treats a part as a single
+    voice, so an unsplit grand staff dumps both staves into one token stream
+    -- inflating NED massively against a kern ground truth that has the
+    staves as separate spines. This isn't limited to piano-only scores (a
+    single <part> document): the same problem occurs whenever a grand staff
+    is combined with other parts, e.g. a solo voice plus piano accompaniment,
+    so we split every matching part rather than only a lone one.
+    """
+    try:
+        root = ET.fromstring(xml_text)  # noqa: S314
+    except ET.ParseError:
+        return xml_text
+
+    parts = root.findall("part")
+    final_parts = [split for part in parts for split in _split_grand_staff_part(part)]
+    if len(final_parts) == len(parts):
+        return xml_text  # nothing was split
+
+    new_root = ET.Element(root.tag, root.attrib)
+    for child in root:
+        if child.tag not in ("part-list", "part"):
+            new_root.append(copy.deepcopy(child))
+
+    part_list = ET.SubElement(new_root, "part-list")
+    for index, final_part in enumerate(final_parts):
+        part_id = f"P{index + 1}"
+        final_part.set("id", part_id)
+        score_part = ET.SubElement(part_list, "score-part", id=part_id)
+        ET.SubElement(score_part, "part-name").text = part_id
+        new_root.append(final_part)
 
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(new_root, encoding="unicode")
 

--- a/validation/ned_score.py
+++ b/validation/ned_score.py
@@ -18,14 +18,17 @@ import tempfile
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import editdistance
 
 from homr.circle_of_fifths import strip_naturals
-from homr.transformer.vocabulary import EncodedSymbol, sort_token_chords
+from homr.transformer.vocabulary import EncodedSymbol, empty, nonote, sort_token_chords
 from training.omr_datasets.humdrum_kern_parser import convert_kern_to_parts
 from training.omr_datasets.music_xml_parser import music_xml_file_to_tokens
+
+if TYPE_CHECKING:
+    import music21 as m21
 
 
 @dataclass
@@ -54,6 +57,98 @@ class TokenEvent(TypedDict):
     act_lift: str | None
     act_articulation: str | None
     act_slur: str | None
+
+
+# ---------------------------------------------------------------------------
+# Known ground-truth reliability exceptions (dataset-specific, opt-in only)
+# ---------------------------------------------------------------------------
+
+# btrkeks/polish-scores' kern transcriptions do not reliably encode SOME articulation
+# marks, even on pages where the source engraving has them on nearly every note.
+# Confirmed by an audit of all 112 samples (grep each kern for every articulation
+# character humdrum_kern_parser.py recognizes):
+#   staccato ('), staccatissimo (`), turn (S or $): ZERO occurrences in ALL 112 samples
+#   accent (^), arpeggiate (:), fermata (;), trill/mordent (t/T/m/M): present normally
+#     (e.g. accent: 377 occurrences across 96/112 samples) - these are NOT excluded
+# Concrete, independently-checkable proof for staccato specifically: sample 79
+# ("Gavotte", Jules Zarembski Op. 29) shows a staccato dot under/over nearly every
+# single note in both staves throughout the whole page - see
+# datasets/polish-scores/79.png - yet its kern transcription
+# (datasets/polish-scores/79.krn) contains zero staccato markers ('):
+#   python -c "print(open('datasets/polish-scores/79.krn').read().count(chr(39)))"   # -> 0
+# Scoring these specific marks against ground truth like this measures the dataset's own
+# transcription completeness, not tool accuracy - staccato hallucination was the single
+# largest confusion pair in the whole polish-scores benchmark (1521 occurrences) before
+# this exclusion existed. Accent, despite also being a large confusion pair, is NOT
+# included here: the audit shows it genuinely is encoded in 86% of samples, so its
+# hallucination rate is real signal about tool accuracy, not a ground-truth artifact.
+#
+# This is a btrkeks/polish-scores transcription artifact, not a property of the underlying
+# scores/edition: the alternative HuggingFace dataset PRAIG/polish-scores covers the same
+# scores and does reliably encode these marks. We still use btrkeks/polish-scores because
+# it ships plain **kern directly, while PRAIG/polish-scores uses **ekern and requires the
+# kernpy package to convert to **kern first - kernpy pins a antlr4-python3-runtime version
+# that hard-conflicts with omegaconf (a transitive dependency of rapidocr, used in homr's
+# live title-detection pipeline). So the transcription gap is accepted as the cost of
+# avoiding that dependency conflict, not because a cleaner-ground-truth dataset is
+# unavailable.
+#
+# This must stay opt-in: every scoring entry point below defaults
+# ignore_unreliable_articulation to False, and only validation/polish-scores.py ever
+# passes True. Other datasets (e.g. smb) have not been audited for the same problem and
+# must not silently inherit this exception just because they share this scoring code.
+
+# Only these specific components are unreliable in this dataset's ground truth (see
+# audit above) - NOT the whole articulation field, which also carries accent, arpeggiate,
+# fermata, trill, mordent etc. that ARE reliably encoded and must keep contributing to
+# the score.
+_UNRELIABLE_ARTICULATION_COMPONENTS = frozenset({"staccato", "staccatissimo", "turn"})
+
+
+def _without_unreliable_articulation(articulation: str) -> str:
+    """Removes only the unreliable components from a (possibly compound,
+    underscore-joined) articulation value, e.g. "accent_staccato" -> "accent" - accent
+    must survive since it is reliably encoded (see audit above), only the co-occurring
+    staccato mark is dropped. nonote (".") and empty ("_") pass through unchanged."""
+    if articulation in (nonote, empty):
+        return articulation
+    kept = [c for c in articulation.split("_") if c not in _UNRELIABLE_ARTICULATION_COMPONENTS]
+    return "_".join(kept) if kept else empty
+
+
+def _strip_articulation_from_parts(
+    parts: list[list[EncodedSymbol]],
+) -> list[list[EncodedSymbol]]:
+    """Native-path counterpart to _strip_articulation_from_score below: rewrites
+    articulation on a copy of every symbol so the unreliable components can never
+    contribute to the diff, without touching rhythm/pitch/lift/slur/position or any
+    other (reliable) articulation component."""
+    result = []
+    for part in parts:
+        new_part = []
+        for s in part:
+            cleared = copy.copy(s)
+            cleared.articulation = _without_unreliable_articulation(s.articulation)
+            new_part.append(cleared)
+        result.append(new_part)
+    return result
+
+
+def _strip_articulation_from_score(score: "m21.stream.Score") -> None:
+    """musicdiff-path counterpart to _strip_articulation_from_parts above: mutates the
+    music21 Score in place, removing only Staccato/Staccatissimo articulations and
+    Turn/InvertedTurn expressions - the same narrow set as the native path, leaving
+    accent, fermata, trill, mordent, etc. untouched."""
+    import music21.articulations as m21_articulations  # noqa: PLC0415
+    import music21.expressions as m21_expressions  # noqa: PLC0415
+
+    unreliable_articulations = (m21_articulations.Staccato, m21_articulations.Staccatissimo)
+    unreliable_expressions = (m21_expressions.Turn, m21_expressions.InvertedTurn)
+    for n in score.recurse().notes:
+        n.articulations = [
+            a for a in n.articulations if not isinstance(a, unreliable_articulations)
+        ]
+        n.expressions = [e for e in n.expressions if not isinstance(e, unreliable_expressions)]
 
 
 # ---------------------------------------------------------------------------
@@ -245,13 +340,23 @@ def _parse_output(
     raw_output: str,
     kern_parser: str = "native",
     xml_parser: str = "native",
+    ignore_unreliable_articulation: bool = False,
 ) -> tuple[list[list[EncodedSymbol]], list[list[EncodedSymbol]]]:
-    """Parse ground-truth kern and tool raw output into aligned per-part token lists."""
+    """Parse ground-truth kern and tool raw output into aligned per-part token lists.
+
+    ignore_unreliable_articulation: see "Known ground-truth reliability exceptions"
+    above - opt-in only, set by callers benchmarking datasets with confirmed-unreliable
+    articulation ground truth.
+    """
     kern_raw = _kern_parts(kern_text, kern_parser)
     gt_parts = [
         _strip_position([t for chord in sort_token_chords(p) for t in chord]) for p in kern_raw
     ]
-    return gt_parts, _pred_parts(raw_output, kern_parser, xml_parser)
+    pred_parts = _pred_parts(raw_output, kern_parser, xml_parser)
+    if ignore_unreliable_articulation:
+        gt_parts = _strip_articulation_from_parts(gt_parts)
+        pred_parts = _strip_articulation_from_parts(pred_parts)
+    return gt_parts, pred_parts
 
 
 # Brute-force exact assignment is only used up to this many parts (8! = 40320
@@ -425,9 +530,16 @@ def _alignment_events(
     return events
 
 
-def compute_ned(kern_text: str, raw_output: str) -> NedResult:
-    """Compute OMR-NED between kern ground truth and tool output (MusicXML or **kern)."""
-    kern_parts, pred_parts = _parse_output(kern_text, raw_output)
+def compute_ned(
+    kern_text: str, raw_output: str, ignore_unreliable_articulation: bool = False
+) -> NedResult:
+    """Compute OMR-NED between kern ground truth and tool output (MusicXML or **kern).
+
+    ignore_unreliable_articulation: see "Known ground-truth reliability exceptions" above.
+    """
+    kern_parts, pred_parts = _parse_output(
+        kern_text, raw_output, ignore_unreliable_articulation=ignore_unreliable_articulation
+    )
     return _ned_from_parts(kern_parts, pred_parts)
 
 
@@ -464,7 +576,9 @@ def _musicdiff_register_once() -> None:
         )
 
 
-def _musicdiff_parse_scores(kern_text: str, raw_output: str) -> tuple:
+def _musicdiff_parse_scores(
+    kern_text: str, raw_output: str, ignore_unreliable_articulation: bool = False
+) -> tuple:
     """Parse kern ground truth and tool output into music21 Score objects.
 
     For kern predictions, acceptSyntaxErrors=True lets converter21 repair malformed
@@ -472,6 +586,8 @@ def _musicdiff_parse_scores(kern_text: str, raw_output: str) -> tuple:
     Each repaired error is counted as an additional edit-distance unit via
     AnnScore.num_syntax_errors_fixed, so they are penalised without completely
     breaking the alignment.
+
+    ignore_unreliable_articulation: see "Known ground-truth reliability exceptions" above.
     """
     import music21 as m21  # noqa: PLC0415
 
@@ -510,10 +626,15 @@ def _musicdiff_parse_scores(kern_text: str, raw_output: str) -> tuple:
     pred_score: m21.stream.Score = (
         pred_raw if isinstance(pred_raw, m21.stream.Score) else m21.stream.Score()
     )
+    if ignore_unreliable_articulation:
+        _strip_articulation_from_score(gt_score)
+        _strip_articulation_from_score(pred_score)
     return gt_score, pred_score
 
 
-def _musicdiff_ned_for_sample(kern_text: str, raw_output: str) -> NedResult:
+def _musicdiff_ned_for_sample(
+    kern_text: str, raw_output: str, ignore_unreliable_articulation: bool = False
+) -> NedResult:
     """Compute OMR-NED using musicdiff's full structural comparison (DetailLevel.Default).
 
     Component NEDs (rhythm, pitch, lift, articulation, slur) are not available in this
@@ -521,11 +642,14 @@ def _musicdiff_ned_for_sample(kern_text: str, raw_output: str) -> NedResult:
     (OMR-ED + syntax_fixes) / (numsyms_gt + numsyms_pred).
 
     Call _musicdiff_register_once() before entering a batch loop.
+    ignore_unreliable_articulation: see "Known ground-truth reliability exceptions" above.
     """
     from musicdiff.annotation import AnnScore  # noqa: PLC0415
     from musicdiff.comparison import Comparison  # noqa: PLC0415
 
-    gt_score, pred_score = _musicdiff_parse_scores(kern_text, raw_output)
+    gt_score, pred_score = _musicdiff_parse_scores(
+        kern_text, raw_output, ignore_unreliable_articulation
+    )
 
     ann_gt: AnnScore = AnnScore(gt_score)
     ann_pred: AnnScore = AnnScore(pred_score)
@@ -553,7 +677,9 @@ def _musicdiff_ned_for_sample(kern_text: str, raw_output: str) -> NedResult:
     )
 
 
-def _musicdiff_detailed_ned_for_sample(kern_text: str, raw_output: str) -> NedResult:
+def _musicdiff_detailed_ned_for_sample(
+    kern_text: str, raw_output: str, ignore_unreliable_articulation: bool = False
+) -> NedResult:
     """Compute OMR-NED with per-component breakdown using multiple musicdiff DetailLevel runs.
 
     Runs 5 separate comparisons to isolate component costs:
@@ -568,12 +694,17 @@ def _musicdiff_detailed_ned_for_sample(kern_text: str, raw_output: str) -> NedRe
 
     Slower than the plain 'musicdiff' mode due to the additional comparisons.
     Call _musicdiff_register_once() before entering a batch loop.
+    ignore_unreliable_articulation: see "Known ground-truth reliability exceptions" above -
+    when set, articulation_ned above is computed from scores with no articulations left on
+    either side, so it will read as 0 (or NaN if artic_syms ends up 0), not a real measurement.
     """
     from musicdiff.annotation import AnnScore  # noqa: PLC0415
     from musicdiff.comparison import Comparison  # noqa: PLC0415
     from musicdiff.detaillevel import DetailLevel  # noqa: PLC0415
 
-    gt_score, pred_score = _musicdiff_parse_scores(kern_text, raw_output)
+    gt_score, pred_score = _musicdiff_parse_scores(
+        kern_text, raw_output, ignore_unreliable_articulation
+    )
 
     def _compare(dl: int) -> tuple[int, int, int, int]:
         """Return (ed, syntax_fixes, gt_size, pred_size) for one DetailLevel."""

--- a/validation/ned_score.py
+++ b/validation/ned_score.py
@@ -12,6 +12,7 @@ import contextlib
 import copy
 import difflib
 import io
+import itertools
 import os
 import tempfile
 import xml.etree.ElementTree as ET
@@ -253,25 +254,93 @@ def _parse_output(
     return gt_parts, _pred_parts(raw_output, kern_parser, xml_parser)
 
 
+# Brute-force exact assignment is only used up to this many parts (8! = 40320
+# permutations, each a handful of editdistance.eval calls - a few tens of ms
+# at most). Real scores in these datasets top out around quartets (4 parts);
+# this is a generous margin above that, not a tuned/observed limit.
+_MAX_PARTS_FOR_EXACT_MATCHING = 8
+
+
+def _greedy_part_permutation(cost: list[list[int]]) -> list[int]:
+    """Fallback for _best_part_permutation when there are too many parts to brute-force:
+    repeatedly take the cheapest remaining (kern-index, xml-index) pair. Not guaranteed
+    optimal, but reasonable, and only reached for part counts not observed in practice.
+    """
+    n = len(cost)
+    remaining_rows = set(range(n))
+    remaining_cols = set(range(n))
+    perm = [-1] * n
+    pairs = sorted((cost[i][j], i, j) for i in range(n) for j in range(n))
+    for _, i, j in pairs:
+        if i in remaining_rows and j in remaining_cols:
+            perm[i] = j
+            remaining_rows.discard(i)
+            remaining_cols.discard(j)
+    return perm
+
+
+def _best_part_permutation(cost: list[list[int]]) -> list[int]:
+    """Returns perm such that pairing row i with column perm[i] minimizes total cost."""
+    n = len(cost)
+    if n <= 1:
+        return list(range(n))
+    if n > _MAX_PARTS_FOR_EXACT_MATCHING:
+        return _greedy_part_permutation(cost)
+    best_perm = list(range(n))
+    best_total = sum(cost[i][best_perm[i]] for i in range(n))
+    for perm in itertools.permutations(range(n)):
+        total = sum(cost[i][j] for i, j in enumerate(perm))
+        if total < best_total:
+            best_total = total
+            best_perm = list(perm)
+    return best_perm
+
+
+def _align_parts(
+    kern_parts: list[list[EncodedSymbol]],
+    xml_parts: list[list[EncodedSymbol]],
+) -> tuple[list[list[EncodedSymbol]], list[list[EncodedSymbol]]]:
+    """
+    Reorders xml_parts (after padding both lists to equal length with empty parts as
+    needed) so that xml_parts[i] is the best content match for kern_parts[i], rather than
+    assuming the two already agree on part order.
+
+    Kern's spine order and a tool's part order do not always follow the same convention -
+    e.g. a kern file can encode a vocal-plus-piano piece as [bass, treble, treble], while
+    homr's split-grand-staff output (see _split_grand_staff) lists [vocal, piano-treble,
+    piano-bass] for the same piece - a near-exact reversal despite every part having a
+    real, correct match. Aligning purely by position would compare kern's bass against
+    homr's vocal part, wildly inflating both the aggregate NED and any per-part
+    diagnostics, even though the transcription itself may be perfectly fine. Matching by
+    minimum total edit distance (an assignment problem, solved exactly for the realistic
+    part counts in these datasets - see _best_part_permutation) finds the correct
+    correspondence regardless of what order either side happens to list parts in.
+    """
+    n = max(len(kern_parts), len(xml_parts), 1)
+    kern_padded = [kern_parts[i] if i < len(kern_parts) else [] for i in range(n)]
+    xml_padded = [xml_parts[i] if i < len(xml_parts) else [] for i in range(n)]
+    cost = [[editdistance.eval(k, x) for x in xml_padded] for k in kern_padded]
+    perm = _best_part_permutation(cost)
+    return kern_padded, [xml_padded[j] for j in perm]
+
+
 def _ned_from_parts(
     kern_parts: list[list[EncodedSymbol]],
     xml_parts: list[list[EncodedSymbol]],
 ) -> NedResult:
-    n = max(len(kern_parts), len(xml_parts), 1)
+    kern_parts, xml_parts = _align_parts(kern_parts, xml_parts)
+    n = len(kern_parts)
 
-    def _kp(i: int) -> list[EncodedSymbol]:
-        return kern_parts[i] if i < len(kern_parts) else []
-
-    def _xp(i: int) -> list[EncodedSymbol]:
-        return xml_parts[i] if i < len(xml_parts) else []
-
-    total_dist = sum(editdistance.eval(_kp(i), _xp(i)) for i in range(n))
+    total_dist = sum(editdistance.eval(kern_parts[i], xml_parts[i]) for i in range(n))
     kern_len = sum(len(k) for k in kern_parts)
     xml_len = sum(len(x) for x in xml_parts)
     denominator = max(kern_len + xml_len, 1)
 
     def _cned(field: str) -> float:
-        return sum(_component_dist(_kp(i), _xp(i), field) for i in range(n)) / denominator
+        return (
+            sum(_component_dist(kern_parts[i], xml_parts[i], field) for i in range(n))
+            / denominator
+        )
 
     return NedResult(
         ned=total_dist / denominator,
@@ -296,12 +365,11 @@ def _events_for_parts(
     kern_parts: list[list[EncodedSymbol]],
     xml_parts: list[list[EncodedSymbol]],
 ) -> list[TokenEvent]:
-    n = max(len(kern_parts), len(xml_parts), 1)
+    kern_parts, xml_parts = _align_parts(kern_parts, xml_parts)
+    n = len(kern_parts)
     events: list[TokenEvent] = []
     for i in range(n):
-        k = kern_parts[i] if i < len(kern_parts) else []
-        x = xml_parts[i] if i < len(xml_parts) else []
-        events.extend(_alignment_events(k, x, _part_staff_name(i, n)))
+        events.extend(_alignment_events(kern_parts[i], xml_parts[i], _part_staff_name(i, n)))
     return events
 
 

--- a/validation/ned_score.py
+++ b/validation/ned_score.py
@@ -338,8 +338,7 @@ def _ned_from_parts(
 
     def _cned(field: str) -> float:
         return (
-            sum(_component_dist(kern_parts[i], xml_parts[i], field) for i in range(n))
-            / denominator
+            sum(_component_dist(kern_parts[i], xml_parts[i], field) for i in range(n)) / denominator
         )
 
     return NedResult(

--- a/validation/polish-scores.py
+++ b/validation/polish-scores.py
@@ -108,6 +108,7 @@ def main() -> None:
             kern_parser=args.kern_parser,
             xml_parser=args.xml_parser,
             limit=args.limit,
+            ignore_unreliable_articulation=True,
         )
         return
 
@@ -123,6 +124,7 @@ def main() -> None:
             batch_size=args.batch_size,
             kern_parser=args.kern_parser,
             xml_parser=args.xml_parser,
+            ignore_unreliable_articulation=True,
         )
 
 


### PR DESCRIPTION
Fixes some staff detection problems which came up in the smb benchmark.

Disclaimer: Claude code changes which mostly accumulated while I was running it in the background, still have to review this myself

Performance changes

```
# Start

System level: 5.5 diffs, SER: 4.1%
Polish scores 24.30%
SMB 23.4%

# Staff parsing

System level: 5.6 diffs, SER: 4.7%
Polish scores 21.40%, 42.63%
SMB 19.98%

# Fix NED scoring

Polish scores 19.98%
SMB 16.60%

# Realized that polish ground truth is missing articulations

Polish scores 17.24% 40.23%

# Undone some claude code changes which looked like poorly justified

Polish Scores: 18.1% 42.10%
SMB: 14.5%
```

It turns out that SMB is also unreliable. For some pieces it omits staccato information which penalizes any model which correctly detect them. I decided to just keep it like that as it's likely not meaningful to spend the time on that.