### PR TITLE
History dropout

### DIFF
--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -126,10 +126,13 @@ class Config:
         # --coreml-encoder CLI flag.
         self.use_coreml_encoder = False
 
-        # Scheduled Sampling parameters
-        self.scheduled_sampling_start_prob = 1.0
-        self.scheduled_sampling_end_prob = 0.4
-        self.scheduled_sampling_decay_steps = 45000
+        # History dropout: probability of corrupting a teacher-forced input token
+        # (replacing it with the pad token) so the decoder cannot shortcut on its
+        # own recent output history and must rely on the cross-attended image
+        # features instead. Ramps up from start to end over decay_steps.
+        self.history_dropout_start_prob = 0.0
+        self.history_dropout_end_prob = 0.15
+        self.history_dropout_decay_steps = 45000
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/training/architecture/transformer/decoder.py
+++ b/training/architecture/transformer/decoder.py
@@ -378,7 +378,7 @@ class ScoreDecoder(nn.Module):
         slurs: torch.Tensor,
         positions: torch.Tensor,
         mask: torch.Tensor,
-        sampling_prob: float = 1.0,
+        history_dropout_prob: float = 0.0,
         **kwargs: Any,
     ) -> dict[str, Any]:
         liftsi = lifts[:, :-1]
@@ -391,66 +391,28 @@ class ScoreDecoder(nn.Module):
         pitchso = pitchs[:, 1:]
         rhythmsi = rhythms[:, :-1]
         rhythmso = rhythms[:, 1:]
-        positionsi = positions[:, :-1]
         positionso = positions[:, 1:]
 
         if mask.shape[1] == rhythms.shape[1]:
             mask = mask[:, :-1]
         mask = mask.bool()
 
-        # Scheduled Sampling: Two-pass approach
-        if self.training and sampling_prob < 1.0:
-            with torch.no_grad():
-                self.net.eval()
-                # First pass to get predictions
-                r_logits, p_logits, l_logits, pos_logits, a_logits, s_logits, _, _, _ = self.net(
-                    rhythms=rhythmsi,
-                    pitchs=pitchsi,
-                    lifts=liftsi,
-                    articulations=articulationsi,
-                    slurs=slursi,
-                    mask=mask,
-                    cache=None,
-                    return_center_of_attention=False,
-                    **kwargs,
-                )
-                self.net.train()
+        # History dropout: corrupt a random subset of teacher-forced input tokens with
+        # the pad token, so the decoder cannot shortcut on its own recent output history
+        # and must rely on the cross-attended image features instead. The BOS token at
+        # position 0 is left untouched. See Plan.md for background.
+        if self.training and history_dropout_prob > 0.0:
+            drop_mask = torch.rand(rhythmsi.shape, device=rhythms.device) < history_dropout_prob
+            drop_mask[:, 0] = False
+            pad = self.config.pad_token
 
-                # Greedy sampling (excluding BOS at index 0)
-                # logits[:, t] predicts tokens[:, t+1] (which is input[:, t+1])
-                # So logits[:, :-1] corresponds to inputs[:, 1:]
-                r_sample = r_logits[:, :-1].argmax(dim=-1)
-                p_sample = p_logits[:, :-1].argmax(dim=-1)
-                l_sample = l_logits[:, :-1].argmax(dim=-1)
-                a_sample = a_logits[:, :-1].argmax(dim=-1)
-                s_sample = s_logits[:, :-1].argmax(dim=-1)
-                pos_sample = pos_logits[:, :-1].argmax(dim=-1)
+            rhythmsi = rhythmsi.masked_fill(drop_mask, pad)
+            pitchsi = pitchsi.masked_fill(drop_mask, pad)
+            liftsi = liftsi.masked_fill(drop_mask, pad)
+            articulationsi = articulationsi.masked_fill(drop_mask, pad)
+            slursi = slursi.masked_fill(drop_mask, pad)
 
-                # Determine which indices to replace
-                mix_mask = (
-                    torch.rand(r_sample.shape, device=rhythms.device) > sampling_prob
-                ).long()
-
-                # Mix inputs
-                rhythmsi = rhythmsi.clone()
-                rhythmsi[:, 1:] = (1 - mix_mask) * rhythmsi[:, 1:] + mix_mask * r_sample
-
-                pitchsi = pitchsi.clone()
-                pitchsi[:, 1:] = (1 - mix_mask) * pitchsi[:, 1:] + mix_mask * p_sample
-
-                liftsi = liftsi.clone()
-                liftsi[:, 1:] = (1 - mix_mask) * liftsi[:, 1:] + mix_mask * l_sample
-
-                articulationsi = articulationsi.clone()
-                articulationsi[:, 1:] = (1 - mix_mask) * articulationsi[:, 1:] + mix_mask * a_sample
-
-                slursi = slursi.clone()
-                slursi[:, 1:] = (1 - mix_mask) * slursi[:, 1:] + mix_mask * s_sample
-
-                positionsi = positionsi.clone()
-                positionsi[:, 1:] = (1 - mix_mask) * positionsi[:, 1:] + mix_mask * pos_sample
-
-        # Second pass (or standard pass) with (possibly mixed) inputs
+        # Forward pass with (possibly corrupted) inputs
         rhythmsp, pitchsp, liftsp, positionsp, articulationsp, slursp, x, _attention, _cache = (
             self.net(
                 rhythms=rhythmsi,

--- a/training/architecture/transformer/tromr_arch.py
+++ b/training/architecture/transformer/tromr_arch.py
@@ -30,7 +30,7 @@ class TrOMR(nn.Module):
         slurs: torch.Tensor,
         positions: torch.Tensor,
         mask: torch.Tensor,
-        sampling_prob: float = 1.0,
+        history_dropout_prob: float = 0.0,
         **kwargs: Any,
     ) -> Any:
         context = self.encoder(inputs)
@@ -43,7 +43,7 @@ class TrOMR(nn.Module):
             positions=positions,
             context=context,
             mask=mask,
-            sampling_prob=sampling_prob,
+            history_dropout_prob=history_dropout_prob,
             **kwargs,
         )
         return loss

--- a/training/transformer/metrics.py
+++ b/training/transformer/metrics.py
@@ -53,17 +53,17 @@ class HomrTrainer(Trainer):
         num_items_in_batch: Tensor | int | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, dict[str, torch.Tensor]]:
         if model.training:
-            # Calculate sampling probability
+            # Calculate history dropout probability (ramps up from start to end)
             config = getattr(model, "config", None)
             if config:
-                start_p = config.scheduled_sampling_start_prob
-                end_p = config.scheduled_sampling_end_prob
-                decay = config.scheduled_sampling_decay_steps
+                start_p = config.history_dropout_start_prob
+                end_p = config.history_dropout_end_prob
+                decay = config.history_dropout_decay_steps
                 step = self.state.global_step
-                sampling_prob = max(end_p, start_p - (start_p - end_p) * (step / decay))
-                inputs["sampling_prob"] = sampling_prob
+                dropout_prob = min(end_p, start_p + (end_p - start_p) * (step / decay))
+                inputs["history_dropout_prob"] = dropout_prob
             else:
-                inputs["sampling_prob"] = 1.0
+                inputs["history_dropout_prob"] = 0.0
 
         outputs = model(**inputs)
         loss = outputs["loss"]

--- a/training/transformer/train.py
+++ b/training/transformer/train.py
@@ -131,11 +131,11 @@ def train_transformer(
 ) -> None:
     distribute = Distribute()
 
-    number_of_epochs = 35
+    number_of_epochs = 30
     if smoke_test:
-        number_of_epochs = 10
+        number_of_epochs = 5
     elif fine_tune:
-        number_of_epochs = 15
+        number_of_epochs = 5
     resume_from_checkpoint = None
 
     checkpoint_folder = "current_training"


### PR DESCRIPTION
Replaces scheduled sampling with history dropout to force the transformer to rely more on image data and less on the sequence history.

E.g. in some examples the transformer start to ignore the image and completely hallucinated tokens. Likely because it learned some typical sequence patterns during training.

@weixlu, could I ask you to do a training run with this branch? A quick 4 epoch run looks okay (SER 17%, system level: 10.7 diffs, SER: 7.6%). To understand if the issue is truly resolved we would unfortunately need a full run.