### PR TITLE
increase timeout for multi-gpu communication

### DIFF
--- a/training/transformer/distribute.py
+++ b/training/transformer/distribute.py
@@ -2,6 +2,7 @@
 # flake8: noqa: S101
 
 import os
+from datetime import timedelta
 
 import torch
 
@@ -20,7 +21,9 @@ class Distribute:
         local_rank = int(os.environ.get("LOCAL_RANK", "0"))
         torch.cuda.set_device(local_rank)
         self._device = torch.device(f"cuda:{local_rank}")
-        torch.distributed.init_process_group(backend="nccl", device_id=self._device)
+        torch.distributed.init_process_group(
+            backend="nccl", device_id=self._device, timeout=timedelta(hours=3)
+        )
         self.enabled = True
         self.rank = torch.distributed.get_rank()
         self.world_size = world_size


### PR DESCRIPTION
Now dataset convertion is added to training pipeline, so we need to increase timeout(default 10min, increased to 3 hours) for multi-gpu communication. Otherwise GPU0 may be doing dataset convertion for a long time, while GPU1 is waiting such a long time that it just timeout
```python
    if distribute.is_rank0():
        _check_datasets_are_present(dataset_index) # take a long time
    distribute.barrier() # timeout
```