### PR TITLE
limit OpenCV thread count

### DIFF
--- a/training/transformer/image_utils.py
+++ b/training/transformer/image_utils.py
@@ -12,6 +12,7 @@ from homr.type_definitions import NDArray
 from training.transformer.augraphy_augment import apply_augraphy
 
 _texture_config: dict = {"dir": None, "paths": None}
+cv2.setNumThreads(0)
 
 
 def set_texture_dir(path: str) -> None:


### PR DESCRIPTION
During transformer training, we have one main process and 12 dataloader processes. After #107 , data augmentation is also performed inside the dataloader, which uses the OpenCV lib (`cv2`).

However, OpenCV itself is still multithreaded. Assuming our machine has 16 CPU cores, OpenCV may create 16 threads inside each dataloader process. This is problematic because the dataloader is already parallelized (12 processes). If each dataloader performs additional parallel work (for example, using 16 OpenCV threads), the total number of threads becomes roughly `12 × 16 = 192`, which is far beyond what our CPU can efficiently handle.

Therefore, I suggest disable OpenCV's internal multithreading.

```python
cv2.setNumThreads(0)
```


I tested this on my machine with both single-GPU and multi-GPU training. The results show that disabling OpenCV multithreading does not affect training speed, while CPU utilization is significantly reduced.

