### PR TITLE
Recover ties from same-pitch slurs

### DIFF
--- a/homr/music_xml_generator.py
+++ b/homr/music_xml_generator.py
@@ -454,30 +454,67 @@ def convert_ties(part: ET.Element) -> None:
     property of a note and its immediate successor.
 
     Run per part rather than per measure, because ties cross barlines. One
-    pass is enough: the last note seen in a voice is by definition the
+    pass is enough: the last event seen in a voice is by definition the
     predecessor of the next one in it.
     """
-    previous: dict[tuple[str, str], ET.Element] = {}
+    previous: dict[tuple[str, str], list[ET.Element]] = {}
     for measure in part.findall("measure"):
-        for note in measure.findall("note"):
-            key = (note.findtext("staff", "1"), note.findtext("voice", "1"))
+        for event in group_into_events(measure):
+            first = event[0]
+            key = (first.findtext("staff", "1"), first.findtext("voice", "1"))
             before = previous.get(key)
-            previous[key] = note
+            previous[key] = event
             if before is None:
                 continue
-            pitch = get_note_pitch(before)
-            if pitch is None or pitch != get_note_pitch(note):
+            tie_event(before, event)
+
+
+def group_into_events(measure: ET.Element) -> list[list[ET.Element]]:
+    """The measure's notes, with each chord kept together as one event.
+
+    A chord is one moment of the music, not several: <chord> means "sounds
+    with the note before". Walking notes one at a time makes a chord's own
+    members each other's neighbours, so nothing in a chord ever finds the note
+    it is really adjacent to, and no tie between two chords is ever seen.
+    """
+    events: list[list[ET.Element]] = []
+    for note in measure.findall("note"):
+        if note.find("chord") is not None and events:
+            events[-1].append(note)
+        else:
+            events.append([note])
+    return events
+
+
+def tie_event(before: list[ET.Element], after: list[ET.Element]) -> None:
+    """Convert every slur between two adjacent events that is really a tie.
+
+    Matched by pitch, and led by the slurs: the model marks the notehead the
+    curve touches, which on a chord is one member and not the whole thing -
+    of the chords carrying a slur on my test material, 25 of 26 had it on
+    some members only. So each slurred note looks for its own pitch in the
+    next event rather than the chord being taken as a whole.
+    """
+    for start_note in before:
+        begins = get_slur(start_note, "start")
+        if begins is None:
+            continue
+        pitch = get_note_pitch(start_note)
+        if pitch is None:
+            continue
+        for stop_note in after:
+            if get_note_pitch(stop_note) != pitch:
                 continue
-            begins = get_slur(before, "start")
-            ends = get_slur(note, "stop")
-            if begins is None or ends is None:
+            ends = get_slur(stop_note, "stop")
+            if ends is None:
                 continue
             begin_slur, begin_notation = begins
             end_slur, end_notation = ends
             begin_notation.remove(begin_slur)
             end_notation.remove(end_slur)
-            add_tie(before, "start", begin_notation)
-            add_tie(note, "stop", end_notation)
+            add_tie(start_note, "start", begin_notation)
+            add_tie(stop_note, "stop", end_notation)
+            break
 
 
 def build_clef(model_clef: EncodedSymbol, attributes: ET.Element) -> None:

--- a/homr/music_xml_generator.py
+++ b/homr/music_xml_generator.py
@@ -137,6 +137,7 @@ def build_part(
     is_first_part = index == 0
     for measure in build_measures(args, voice, is_first_part, has_two_staves):
         part.append(measure)
+    convert_ties(part)
     return part
 
 
@@ -408,6 +409,82 @@ def rebalance_measure_voices(measure: ET.Element) -> None:
                 voice_el = note.find("voice")
                 if voice_el is not None:
                     voice_el.text = xml_voice
+
+
+def get_note_pitch(note: ET.Element) -> str | None:
+    pitch = note.find("pitch")
+    if pitch is None:
+        return None
+    return "|".join(pitch.findtext(part, "") for part in ("step", "alter", "octave"))
+
+
+def get_slur(note: ET.Element, slur_type: str) -> tuple[ET.Element, ET.Element] | None:
+    """The note's slur of this type with the notations holding it, if any.
+
+    build_slurs writes at most one start and one stop per note, so there is
+    never a choice to make here.
+    """
+    for notation in note.findall("notations"):
+        for slur in notation.findall("slur"):
+            if slur.get("type") == slur_type:
+                return slur, notation
+    return None
+
+
+def add_tie(note: ET.Element, tie_type: str, notation: ET.Element) -> None:
+    """A tie needs both elements: <tie> for what sounds, <tied> for what is drawn."""
+    tie = ET.Element("tie", type=tie_type)
+    duration = note.find("duration")
+    position = list(note).index(duration) + 1 if duration is not None else 0
+    note.insert(position, tie)
+    notation.insert(0, ET.Element("tied", type=tie_type))
+
+
+def convert_ties(part: ET.Element) -> None:
+    """Rewrite slurs which are really ties, over a whole part.
+
+    The model learns slurs and ties as one class on purpose, so a tie reaches
+    us as a slur. A slur is a tie when it joins a note to the very next note
+    of its own voice and both carry the same pitch.
+
+    Deliberately no attempt to pair slur starts with slur stops. The slur
+    number is the staff number, so several slurs open on one staff share a
+    number and cannot be told apart by it — four at once on a test file — and
+    any pairing rule would be guessing. A tie needs no pairing: it is a
+    property of a note and its immediate successor.
+
+    Run per part rather than per measure, because ties cross barlines.
+    """
+    notes: list[ET.Element] = []
+    for measure in part.findall("measure"):
+        notes.extend(measure.findall("note"))
+
+    successor: dict[int, int] = {}
+    latest: dict[tuple[str, str], int] = {}
+    for index in reversed(range(len(notes))):
+        note = notes[index]
+        key = (note.findtext("staff", "1"), note.findtext("voice", "1"))
+        if key in latest:
+            successor[index] = latest[key]
+        latest[key] = index
+
+    for index, note in enumerate(notes):
+        following = successor.get(index)
+        if following is None:
+            continue
+        pitch = get_note_pitch(note)
+        if pitch is None or pitch != get_note_pitch(notes[following]):
+            continue
+        begins = get_slur(note, "start")
+        ends = get_slur(notes[following], "stop")
+        if begins is None or ends is None:
+            continue
+        begin_slur, begin_notation = begins
+        end_slur, end_notation = ends
+        begin_notation.remove(begin_slur)
+        end_notation.remove(end_slur)
+        add_tie(note, "start", begin_notation)
+        add_tie(notes[following], "stop", end_notation)
 
 
 def build_clef(model_clef: EncodedSymbol, attributes: ET.Element) -> None:

--- a/homr/music_xml_generator.py
+++ b/homr/music_xml_generator.py
@@ -453,38 +453,31 @@ def convert_ties(part: ET.Element) -> None:
     any pairing rule would be guessing. A tie needs no pairing: it is a
     property of a note and its immediate successor.
 
-    Run per part rather than per measure, because ties cross barlines.
+    Run per part rather than per measure, because ties cross barlines. One
+    pass is enough: the last note seen in a voice is by definition the
+    predecessor of the next one in it.
     """
-    notes: list[ET.Element] = []
+    previous: dict[tuple[str, str], ET.Element] = {}
     for measure in part.findall("measure"):
-        notes.extend(measure.findall("note"))
-
-    successor: dict[int, int] = {}
-    latest: dict[tuple[str, str], int] = {}
-    for index in reversed(range(len(notes))):
-        note = notes[index]
-        key = (note.findtext("staff", "1"), note.findtext("voice", "1"))
-        if key in latest:
-            successor[index] = latest[key]
-        latest[key] = index
-
-    for index, note in enumerate(notes):
-        following = successor.get(index)
-        if following is None:
-            continue
-        pitch = get_note_pitch(note)
-        if pitch is None or pitch != get_note_pitch(notes[following]):
-            continue
-        begins = get_slur(note, "start")
-        ends = get_slur(notes[following], "stop")
-        if begins is None or ends is None:
-            continue
-        begin_slur, begin_notation = begins
-        end_slur, end_notation = ends
-        begin_notation.remove(begin_slur)
-        end_notation.remove(end_slur)
-        add_tie(note, "start", begin_notation)
-        add_tie(notes[following], "stop", end_notation)
+        for note in measure.findall("note"):
+            key = (note.findtext("staff", "1"), note.findtext("voice", "1"))
+            before = previous.get(key)
+            previous[key] = note
+            if before is None:
+                continue
+            pitch = get_note_pitch(before)
+            if pitch is None or pitch != get_note_pitch(note):
+                continue
+            begins = get_slur(before, "start")
+            ends = get_slur(note, "stop")
+            if begins is None or ends is None:
+                continue
+            begin_slur, begin_notation = begins
+            end_slur, end_notation = ends
+            begin_notation.remove(begin_slur)
+            end_notation.remove(end_slur)
+            add_tie(before, "start", begin_notation)
+            add_tie(note, "stop", end_notation)
 
 
 def build_clef(model_clef: EncodedSymbol, attributes: ET.Element) -> None:

--- a/tests/test_music_xml_generator.py
+++ b/tests/test_music_xml_generator.py
@@ -237,6 +237,51 @@ barline . . . . ."""
         # the slur it came from is gone
         self.assertEqual(_slurs(xml), [])
 
+    def test_tie_between_two_chords(self) -> None:
+        """Every notehead of a chord ties to its own pitch in the next one."""
+        chords = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ slurStart upper&note_4 E4 _ _ slurStart upper
+note_4 C4 _ _ slurStop upper&note_4 E4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(chords.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(sorted(_ties(xml)), ["start", "start", "stop", "stop"])
+        self.assertEqual(_slurs(xml), [])
+
+    def test_tie_on_one_notehead_of_a_chord(self) -> None:
+        """The model marks the notehead the curve touches, not the whole chord.
+
+        On real output almost every slurred chord carries the slur on some of
+        its members only, so a tie has to be found for that pitch alone and
+        leave the rest of the chord as it is.
+        """
+        chords = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ _ upper&note_4 E4 _ _ slurStart upper
+note_4 C4 _ _ _ upper&note_4 E4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(chords.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_ties(xml), ["start", "stop"])
+        self.assertEqual(_slurs(xml), [])
+        tied = [n for n in xml.iter("note") if n.find("tie") is not None]
+        self.assertEqual([_pitch(n) for n in tied], ["E", "E"])
+
+    def test_slur_from_a_chord_to_a_different_pitch_stays_a_slur(self) -> None:
+        chords = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ _ upper&note_4 E4 _ _ slurStart upper
+note_4 C4 _ _ _ upper&note_4 G4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(chords.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_slurs(xml), ["start", "stop"])
+        self.assertEqual(_ties(xml), [])
+
     def test_slur_between_different_pitches_stays_a_slur(self) -> None:
         phrase = """clef_G2 . . . . upper
 timeSignature/4 . . . . .

--- a/tests/test_music_xml_generator.py
+++ b/tests/test_music_xml_generator.py
@@ -282,6 +282,42 @@ barline . . . . ."""
         self.assertEqual(_slurs(xml), ["start", "stop"])
         self.assertEqual(_ties(xml), [])
 
+    def test_phrase_slur_over_three_events_stays_a_slur(self) -> None:
+        """Adjacency is what separates a tie from a phrase mark.
+
+        A curve that leaves a pitch and comes back to it later is a phrase,
+        however identical its two ends are, so only the immediately following
+        event may close a tie.
+        """
+        phrase = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ _ upper&note_4 G4 _ _ slurStart upper
+note_4 A4 _ _ _ upper
+note_4 C4 _ _ _ upper&note_4 G4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(phrase.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_slurs(xml), ["start", "stop"])
+        self.assertEqual(_ties(xml), [])
+
+    def test_shared_pitch_without_a_slur_of_its_own_stays_untied(self) -> None:
+        """A pitch in both chords is not enough; the curve has to be on it.
+
+        Here C4 is in both chords and the curve runs from G4 to C4, so nothing
+        ties: G4 has no stop to reach, and C4 has no start behind it.
+        """
+        crossing = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ _ upper&note_4 G4 _ _ slurStart upper
+note_4 C4 _ _ slurStop upper&note_4 A4 _ _ _ upper
+barline . . . . ."""
+        tokens = read_token_lines(crossing.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_slurs(xml), ["start", "stop"])
+        self.assertEqual(_ties(xml), [])
+
     def test_slur_between_different_pitches_stays_a_slur(self) -> None:
         phrase = """clef_G2 . . . . upper
 timeSignature/4 . . . . .

--- a/tests/test_music_xml_generator.py
+++ b/tests/test_music_xml_generator.py
@@ -6,6 +6,7 @@ import xml.etree.ElementTree as ET
 from homr.music_xml_generator import (
     SymbolChord,
     XmlGeneratorArguments,
+    convert_ties,
     generate_xml,
     rebalance_measure_voices,
 )
@@ -42,6 +43,18 @@ def _staff(note: ET.Element) -> str:
 
 def _backups(measure: ET.Element) -> list[int]:
     return [int(c.findtext("duration", "0")) for c in measure if c.tag == "backup"]
+
+
+def _ties(xml: ET.Element) -> list[str]:
+    return [t.get("type", "") for t in xml.iter("tie")]
+
+
+def _tieds(xml: ET.Element) -> list[str]:
+    return [t.get("type", "") for t in xml.iter("tied")]
+
+
+def _slurs(xml: ET.Element) -> list[str]:
+    return [s.get("type", "") for s in xml.iter("slur")]
 
 
 def _first_measure(xml: ET.Element) -> ET.Element:
@@ -205,3 +218,100 @@ barline . . . . ."""
         v = note.findtext("voice")
         self.assertIsNotNone(v)
         return str(v)
+
+    def test_slur_between_same_pitches_becomes_a_tie(self) -> None:
+        """A slur joining two identical pitches is a tie, and needs both elements."""
+        tied = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ slurStart upper
+note_4 C4 _ _ slurStop upper
+note_2 D4 _ _ _ upper
+barline . . . . ."""
+        tokens = read_token_lines(tied.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        # <tie> is what sounds, <tied> is what is drawn: both are required, or
+        # the notes are drawn joined and still played separately.
+        self.assertEqual(_ties(xml), ["start", "stop"])
+        self.assertEqual(_tieds(xml), ["start", "stop"])
+        # the slur it came from is gone
+        self.assertEqual(_slurs(xml), [])
+
+    def test_slur_between_different_pitches_stays_a_slur(self) -> None:
+        phrase = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ slurStart upper
+note_4 E4 _ _ slurStop upper
+note_2 D4 _ _ _ upper
+barline . . . . ."""
+        tokens = read_token_lines(phrase.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_slurs(xml), ["start", "stop"])
+        self.assertEqual(_ties(xml), [])
+
+    def test_tie_is_recognised_across_a_barline(self) -> None:
+        """Ties cross barlines constantly, which is why the pass runs per part."""
+        across = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_1 C4 _ _ slurStart upper
+barline . . . . .
+note_1 C4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(across.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_ties(xml), ["start", "stop"])
+        self.assertEqual(_slurs(xml), [])
+
+    def test_same_pitch_but_not_adjacent_stays_a_slur(self) -> None:
+        """Same pitch is not enough: a tie joins a note to its immediate successor."""
+        apart = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 C4 _ _ slurStart upper
+note_4 E4 _ _ _ upper
+note_4 C4 _ _ slurStop upper
+note_4 D4 _ _ _ upper
+barline . . . . ."""
+        tokens = read_token_lines(apart.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        self.assertEqual(_ties(xml), [])
+        self.assertEqual(_slurs(xml), ["start", "stop"])
+
+    def test_convert_ties_leaves_a_part_without_slurs_alone(self) -> None:
+        part = ET.Element("part", id="P1")
+        measure = ET.SubElement(part, "measure", number="1")
+        note = ET.SubElement(measure, "note")
+        pitch = ET.SubElement(note, "pitch")
+        ET.SubElement(pitch, "step").text = "C"
+        ET.SubElement(pitch, "octave").text = "4"
+        ET.SubElement(note, "duration").text = "4"
+        ET.SubElement(note, "voice").text = "1"
+        ET.SubElement(note, "staff").text = "1"
+
+        convert_ties(part)
+        self.assertEqual(_ties(part), [])
+
+    def test_tie_found_while_another_slur_is_open_on_the_same_staff(self) -> None:
+        """Several slurs share a staff, and so share a slur number.
+
+        The tie here opens and closes inside a longer slur. Nothing can tell
+        the two apart by number, which is why ties are detected from a note
+        and its successor rather than by pairing starts with stops.
+        """
+        nested = """clef_G2 . . . . upper
+timeSignature/4 . . . . .
+note_4 E4 _ _ slurStart upper
+note_4 C4 _ _ slurStart upper
+note_4 C4 _ _ slurStop upper
+note_4 G4 _ _ slurStop upper
+barline . . . . ."""
+        tokens = read_token_lines(nested.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+
+        # the inner pair became a tie
+        self.assertEqual(_ties(xml), ["start", "stop"])
+        self.assertEqual(_tieds(xml), ["start", "stop"])
+        # the outer slur is untouched
+        self.assertEqual(_slurs(xml), ["start", "stop"])


### PR DESCRIPTION
Refs #139. Implements the suggestion from @aicelen there: since the model
learns slurs and ties as one class, a tie can be read back out of the slurs.

A slur is treated as a tie when it joins a note to the very next note of its
own voice and both carry the same pitch. `convert_ties()` runs once per part
from `build_part()`, after its measures are built — per part rather than per
measure because ties cross barlines constantly.

**No pairing of slur starts with stops.** `slur_number` is the staff number, so
every slur on a staff shares a number and they cannot be told apart by it — I
found four open at once on one test file. Any pairing rule would be guessing,
and a tie needs none: it is a property of a note and its immediate successor.
`build_slurs()` writes at most one start and one stop per note, so which
element to remove is never ambiguous either.

A converted pair gets **both** `<tie>` and `<tied>`. Only `<tied>` was written
before, so a detected tie drew as a curve while both notes still sounded
separately — @weixlu reports running into that too.

## Results

Measured against known-good encodings. Engraved input, where curve detection
is good:

| source | ties | found | correct | recall | precision |
|---|---|---|---|---|---|
| Bach, WTC I Prelude in C (BWV 846) | 68 | 65 | 63 | 0.93 | 0.97 |
| Satie, Gymnopédie No. 1 | 14 | 14 | 14 | 1.00 | 1.00 |

Scanned editions, against Craig Sapp's kern, where it is not:

| source | ties | found | correct | recall | precision |
|---|---|---|---|---|---|
| Joplin, Heliotrope Bouquet | 189 | 31 | 23 | 0.12 | 0.74 |
| Chopin, Mazurka Op. 41 No. 2 | 85 | 3 | 3 | 0.04 | 1.00 |

A Beethoven scan with 22 slur pairs and no ties gains none.

**The scan figures are detection, not conversion.** On the Joplin page carrying
51 ties the model emits about 25 curves; on the Chopin it finds roughly 77
curves for 123 real ones, but their endpoints rarely land on two adjacent notes
of one pitch. Resolution is not the cause — 2538px and 5076px inputs give
identical output. This is the weakness described in #81, measured on scans.

The Chopin also has 38 phrase slurs and none of them was converted, which is
the failure mode I most wanted to rule out.

BWV 846's five misses are all in the closing bars, where the model puts a slur
start on a treble note and its stop two staves below — not a tie by any
reading. Relaxing the rule from "next note in this voice" to "next note on this
staff" recovers none of them, so it is already extracting what the model
provides.

So: ties are recovered wherever the curve is detected accurately, and nothing
is invented where it is not.

## Tests

Six cases added to `tests/test_music_xml_generator.py`: same pitch becomes a
tie; different pitch stays a slur; a tie across a barline; same pitch but not
adjacent stays a slur; a part with no slurs is untouched; and a tie nested
inside a longer slur on the same staff, which is the case the shared slur
number makes ambiguous.

`make ci` passes — 73 tests, ruff, black, isort and mypy clean.

The `<accidental>` and `<beam>` questions from #139 are deliberately left out
of this PR so they can be taken or refused separately.
