### PR TITLE
parse multi voice in staff

### DIFF
--- a/homr/music_xml_generator.py
+++ b/homr/music_xml_generator.py
@@ -14,6 +14,7 @@ from homr.transformer.vocabulary import (
     EncodedSymbol,
     SymbolDuration,
     empty,
+    is_lower_position,
     nonote,
     sort_token_chords,
 )
@@ -73,22 +74,15 @@ class SymbolChord:
         return min(notes_rests)
 
     def into_positions(self) -> list["SymbolChord"]:
-        upper = []
-        lower = []
-        lower_is_only_rest = True
+        buckets: dict[str, list[EncodedSymbol]] = defaultdict(list)
         for symbol in self.symbols:
-            if symbol.position == "upper":
-                upper.append(symbol)
-            else:
-                lower.append(symbol)
-                lower_is_only_rest = lower_is_only_rest and symbol.rhythm.startswith("rest")
-        chords = (
-            SymbolChord(upper, self.tuplet_mark),
-            SymbolChord(lower, self.tuplet_mark),
+            buckets[symbol.position].append(symbol)
+        chords = [SymbolChord(symbols, self.tuplet_mark) for symbols in buckets.values()]
+        # Voices of only rests go first, the last chord is the one which advances time.
+        chords.sort(
+            key=lambda chord: all(s.rhythm.startswith("rest") for s in chord.symbols), reverse=True
         )
-        if lower_is_only_rest:
-            chords = (chords[1], chords[0])
-        return [chord for chord in chords if len(chord.symbols) > 0]
+        return chords
 
 
 class XmlGeneratorArguments:
@@ -127,7 +121,7 @@ def xml_to_string(element: ET.Element) -> str:
 
 def _voice_has_two_staves(voice: list[EncodedSymbol]) -> bool:
     """True if any symbol uses the lower staff (e.g. piano left hand / bass clef)."""
-    return any(s.position == "lower" for s in voice)
+    return any(is_lower_position(s.position) for s in voice)
 
 
 def build_part(
@@ -325,7 +319,7 @@ def build_key(model_key: EncodedSymbol, attributes: ET.Element) -> None:
 
 
 def get_staff(symbol: EncodedSymbol) -> int:
-    return 2 if symbol.position == "lower" else 1
+    return 2 if is_lower_position(symbol.position) else 1
 
 
 def get_xml_voice(staff_num: int, rhythmic_layer: int) -> int:

--- a/homr/staff_parsing_tromr.py
+++ b/homr/staff_parsing_tromr.py
@@ -1,7 +1,7 @@
 from homr.model import Staff
 from homr.transformer.configs import Config
 from homr.transformer.staff2score import Staff2Score
-from homr.transformer.vocabulary import EncodedSymbol
+from homr.transformer.vocabulary import EncodedSymbol, is_lower_position
 from homr.type_definitions import NDArray
 
 inference: Staff2Score | None = None
@@ -19,4 +19,4 @@ def predict_best(org_image: NDArray, staff: Staff, config: Config) -> list[Encod
     result = inference.predict(org_image)
     if staff.is_grandstaff:
         return result
-    return [r for r in result if r.position != "lower"]
+    return [r for r in result if not is_lower_position(r.position)]

--- a/homr/transformer/configs.py
+++ b/homr/transformer/configs.py
@@ -10,7 +10,7 @@ root_dir = os.getcwd()
 
 class FilePaths:
     def __init__(self) -> None:
-        model_name = "pytorch_model_426-b6fd20809a8dcaf10dfd39a4ca4f64c6f056e644"
+        model_name = "pytorch_model_445-a7dc8cc7d7e995806f5be53598cb70af8876f1df"
         self.encoder_path = os.path.join(
             workspace,
             f"encoder_{model_name}.onnx",

--- a/homr/transformer/vocabulary.py
+++ b/homr/transformer/vocabulary.py
@@ -94,8 +94,12 @@ def build_position() -> dict[str, int]:
     """
     The staff position, applies to notes, rests and clefs
     """
-    positions = [nonote, "upper", "lower"]
+    positions = [nonote, "upper", "upper2", "lower", "lower2"]
     return build_dict(positions)
+
+
+def is_lower_position(position: str) -> bool:
+    return position.startswith("lower")
 
 
 def build_articulation() -> dict[str, int]:
@@ -337,10 +341,10 @@ class EncodedSymbol:
         return result
 
     def to_upper_position(self) -> "EncodedSymbol":
-        if self.position != "lower":
+        if not is_lower_position(self.position):
             return self
         result = copy.copy(self)
-        result.position = "upper"
+        result.position = self.position.replace("lower", "upper")
         return result
 
     def is_valid(self) -> bool:
@@ -472,7 +476,7 @@ def _remove_redudant_clefs_keys_and_time_signatures(
         result = []
         for symbol in chord:
             if symbol.rhythm.startswith("clef"):
-                if symbol.position == "upper":
+                if not is_lower_position(symbol.position):
                     if symbol.rhythm != clef_upper:
                         clef_upper = symbol.rhythm
                         result.append(symbol)
@@ -607,7 +611,7 @@ def _only_keep_lower_staff_if_there_is_a_clef(
         for symbol in chord:
             if has_lower_clef:
                 result.append(symbol)
-            elif i < 5 and symbol.rhythm.startswith("clef") and symbol.position == "lower":
+            elif i < 5 and symbol.rhythm.startswith("clef") and is_lower_position(symbol.position):
                 has_lower_clef = True
                 result.append(symbol)
             else:

--- a/tests/test_humdrum_kern_parser.py
+++ b/tests/test_humdrum_kern_parser.py
@@ -88,17 +88,17 @@ repeatEnd . . . . ."""
         expected = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
 keySignature_-2 . . . . .
 timeSignature/4 . . . . .
-note_8 G4 _ _ _ upper&rest_4 _ _ _ _ upper&note_8 G3 _ _ _ lower&note_8 G2 _ _ _ lower&rest_4 _ _ _ _ lower
-note_16 D5 _ _ _ upper&note_8 G3 _ _ _ lower&note_8 B2 b _ _ lower
+note_8 G4 _ _ _ upper&rest_4 _ _ _ _ upper2&note_8 G3 _ _ _ lower2&note_8 G2 _ _ _ lower2&rest_4 _ _ _ _ lower
+note_16 D5 _ _ _ upper&note_8 G3 _ _ _ lower2&note_8 B2 b _ _ lower2
 note_16 D4 _ _ _ upper
-note_8 E4 b _ _ upper&rest_4 _ _ _ _ upper&note_8 G3 _ _ _ lower&note_8 C3 _ _ _ lower&rest_4 _ _ _ _ lower
-note_16 C5 _ _ _ upper&note_8 A3 _ _ _ lower&note_8 A2 _ _ _ lower
+note_8 E4 b _ _ upper&rest_4 _ _ _ _ upper2&note_8 G3 _ _ _ lower2&note_8 C3 _ _ _ lower2&rest_4 _ _ _ _ lower
+note_16 C5 _ _ _ upper&note_8 A3 _ _ _ lower2&note_8 A2 _ _ _ lower2
 note_16 F4 # _ _ upper
-note_4. G4 _ _ _ upper&note_8 G4 _ _ _ upper&note_4 G3 _ _ _ lower&note_8 B2 b _ _ lower
-note_16 E4 b _ _ upper&note_8 C3 _ _ _ lower
-note_16 C4 _ _ _ upper
-note_8 B3 b _ _ upper&note_8 D3 _ _ _ lower&rest_4 _ _ _ _ lower
-note_8 F4 # _ _ upper&note_8 D4 _ _ _ upper&note_8 C4 _ _ _ upper&note_8 A3 _ _ _ upper&note_8 D2 _ _ _ lower
+note_4. G4 _ _ _ upper&note_8 G4 _ _ _ upper2&note_4 G3 _ _ _ lower&note_8 B2 b _ _ lower2
+note_16 E4 b _ _ upper2&note_8 C3 _ _ _ lower2
+note_16 C4 _ _ _ upper2
+note_8 B3 b _ _ upper2&note_8 D3 _ _ _ lower&rest_4 _ _ _ _ lower2
+note_8 F4 # _ _ upper&note_8 D4 _ _ _ upper2&note_8 C4 _ _ _ upper2&note_8 A3 _ _ _ upper2&note_8 D2 _ _ _ lower
 barline . . . . .
 note_1 D4 _ _ _ upper&note_1 B3 b _ _ upper&note_1 G2 _ _ _ lower
 repeatEnd . . . . ."""
@@ -497,14 +497,14 @@ barline . . . . ."""
         expected = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
 keySignature_0 . . . . .
 timeSignature/4 . . . . .
-note_16 B4 _ _ _ upper&rest_8 _ _ _ _ upper&note_8 E2 _ _ _ lower
-note_16 G4 # _ _ upper
-note_8 E5 _ _ _ upper&note_16 E4 _ _ _ upper&rest_8 _ _ _ _ lower
-note_16 G4 # _ _ upper
-note_8 F5 _ _ _ upper&note_16 B4 _ _ _ upper&rest_4 _ _ _ _ lower
-note_16 G4 # _ _ upper
-note_8 E5 _ _ _ upper&note_16 E4 _ _ _ upper
-note_16 G4 # _ _ upper
+note_16 B4 _ _ _ upper2&rest_8 _ _ _ _ upper&note_8 E2 _ _ _ lower
+note_16 G4 # _ _ upper2
+note_8 E5 _ _ _ upper&note_16 E4 _ _ _ upper2&rest_8 _ _ _ _ lower
+note_16 G4 # _ _ upper2
+note_8 F5 _ _ _ upper&note_16 B4 _ _ _ upper2&rest_4 _ _ _ _ lower
+note_16 G4 # _ _ upper2
+note_8 E5 _ _ _ upper&note_16 E4 _ _ _ upper2
+note_16 G4 # _ _ upper2
 barline . . . . ."""
         self.maxDiff = None
         self.assertEqual(tokens, expected)

--- a/tests/test_music_xml_generator.py
+++ b/tests/test_music_xml_generator.py
@@ -139,6 +139,24 @@ barline . . . . ."""
             else:
                 self.assertGreaterEqual(v, 5)
 
+    def test_two_voices_on_the_same_staff(self) -> None:
+        two_voices = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
+keySignature_0 . . . . .
+timeSignature/4 . . . . .
+note_2 G4 _ _ _ upper&note_4 E4 _ _ _ upper2&note_1 C3 _ _ _ lower
+note_4 D4 _ _ _ upper2
+barline . . . . ."""
+        tokens = read_token_lines(two_voices.splitlines())
+        xml = generate_xml(XmlGeneratorArguments(), [tokens], "")
+        by_pitch = {_pitch(n): n for n in _notes(_first_measure(xml))}
+
+        # The second voice belongs to the upper staff, but is a voice of its own
+        # instead of being a chord note of the first voice.
+        self.assertEqual(_staff(by_pitch["E"]), "1")
+        self.assertIsNone(by_pitch["E"].find("chord"))
+        self.assertNotEqual(_voice(by_pitch["E"]), _voice(by_pitch["G"]))
+        self.assertEqual(_voice(by_pitch["E"]), _voice(by_pitch["D"]))
+
     def test_begin_chord_with_standalone_rests(self) -> None:
         """
         If the lower position consists of a standalone rest then start the

--- a/tests/test_music_xml_parser.py
+++ b/tests/test_music_xml_parser.py
@@ -2,10 +2,13 @@
 
 import re
 import unittest
+import xml.etree.ElementTree as ET
 from typing import Any
 
+from homr.music_xml_generator import XmlGeneratorArguments, generate_xml
 from training.omr_datasets.music_xml_parser import music_xml_string_to_tokens
 from training.transformer.training_vocabulary import (
+    read_token_lines,
     token_lines_to_str,
 )
 
@@ -154,9 +157,9 @@ class TestMusicXmlParser(unittest.TestCase):
         expected = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
 keySignature_1 . . . . .
 timeSignature/4 . . . . .
-note_1 G4 _ _ slurStart_slurStop upper&note_1 A3 # _ _ upper&rest_2 _ _ _ _ upper&note_4 G3 _ _ slurStop lower
+note_1 G4 _ _ slurStart_slurStop upper&note_1 A3 # _ _ upper&rest_2 _ _ _ _ upper2&note_4 G3 _ _ slurStop lower
 rest_4 _ _ _ _ lower
-note_2 E4 _ _ slurStart upper&note_2 C2 _ _ _ lower
+note_2 E4 _ _ slurStart upper2&note_2 C2 _ _ _ lower
 barline . . . . ."""
         self.assertEqual(token_str, expected)
 
@@ -447,8 +450,8 @@ timeSignature/4 . . . . .
 note_12 B5 _ _ slurStart_slurStop upper&note_12 G5 _ _ _ upper&note_4 B1 _ _ _ lower
 note_12 G5 _ staccato _ upper&note_12 D5 # _ _ upper
 note_12 D5 # staccato _ upper&note_12 B4 _ _ _ upper
-note_2 B4 _ _ slurStart_slurStop upper&note_4 G4 _ _ _ upper&note_4 B3 _ _ _ lower&note_4 D3 # _ _ lower
-note_4 A4 _ _ slurStop upper&note_4 F4 # _ _ upper&note_4 B3 _ _ _ lower&note_4 D3 # _ _ lower
+note_2 B4 _ _ slurStart_slurStop upper&note_4 G4 _ _ _ upper2&note_4 B3 _ _ _ lower&note_4 D3 # _ _ lower
+note_4 A4 _ _ slurStop upper2&note_4 F4 # _ _ upper2&note_4 B3 _ _ _ lower&note_4 D3 # _ _ lower
 barline . . . . ."""
         self.assertEqual(token_str, expected)
 
@@ -509,6 +512,126 @@ timeSignature/4 . . . . .
 note_1 D5 _ _ _ upper&note_1 D4 _ _ _ upper&note_1 B3 _ arpeggiate _ lower&note_1 D3 _ _ _ lower&note_1 G2 _ _ _ lower
 barline . . . . ."""
         self.assertEqual(token_str, expected)
+
+    def test_two_voices_on_one_staff(self) -> None:
+        """The first visible voice of a staff is the main voice, the others get a "2"
+        suffix. Here voice 2 is written before voice 1 and voice 3 is folded into
+        the second voice."""
+        self.maxDiff = None
+        example = """<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>4</divisions>
+        <key><fifths>0</fifths></key>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef number="1"><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>E</step><octave>4</octave></pitch>
+        <duration>8</duration><voice>2</voice><type>half</type><staff>1</staff>
+      </note>
+      <note>
+        <pitch><step>D</step><octave>4</octave></pitch>
+        <duration>8</duration><voice>2</voice><type>half</type><staff>1</staff>
+      </note>
+      <backup><duration>16</duration></backup>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>16</duration><voice>1</voice><type>whole</type><staff>1</staff>
+      </note>
+      <backup><duration>16</duration></backup>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>16</duration><voice>3</voice><type>whole</type><staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+        tokens = music_xml_string_to_tokens(example)
+        flat_list = [x for xxs in tokens for xs in xxs for x in xs]
+        token_str = token_lines_to_str(flat_list)
+        expected = """clef_G2 _ _ _ _ upper
+keySignature_0 . . . . .
+timeSignature/4 . . . . .
+note_1 G4 _ _ _ upper2&note_2 E4 _ _ _ upper&note_1 C4 _ _ _ upper2
+note_2 D4 _ _ _ upper
+barline . . . . ."""
+        self.assertEqual(token_str, expected)
+
+    def test_voice_assignment_is_per_staff_and_measure(self) -> None:
+        """Hidden rests do not claim a voice; each staff and measure starts fresh."""
+        example = """<score-partwise version="4.0"><part id="P1">
+<measure number="1">
+  <attributes>
+    <divisions>1</divisions>
+    <clef number="1"><sign>G</sign><line>2</line></clef>
+    <clef number="2"><sign>F</sign><line>4</line></clef>
+  </attributes>
+  <note print-object="no">
+    <rest/><duration>1</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+  </note>
+  <backup><duration>1</duration></backup>
+  <note>
+    <rest/><duration>1</duration><voice>2</voice><type>quarter</type><staff>1</staff>
+  </note>
+  <backup><duration>1</duration></backup>
+  <note>
+    <pitch><step>C</step><octave>4</octave></pitch>
+    <duration>1</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+  </note>
+  <note>
+    <chord/><pitch><step>E</step><octave>4</octave></pitch>
+    <duration>1</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+  </note>
+  <backup><duration>1</duration></backup>
+  <note>
+    <pitch><step>C</step><octave>3</octave></pitch>
+    <duration>1</duration><voice>1</voice><type>quarter</type><staff>2</staff>
+  </note>
+  <backup><duration>1</duration></backup>
+  <note>
+    <rest/><duration>1</duration><voice>2</voice><type>quarter</type><staff>2</staff>
+  </note>
+</measure>
+<measure number="2">
+  <note>
+    <pitch><step>D</step><octave>4</octave></pitch>
+    <duration>1</duration><voice>1</voice><type>quarter</type><staff>1</staff>
+  </note>
+</measure>
+</part></score-partwise>"""
+        tokens = music_xml_string_to_tokens(example)
+        symbols = [s for page in tokens for measure in page for s in measure]
+        notes = {s.pitch: s.position for s in symbols if s.rhythm.startswith("note")}
+        self.assertEqual(notes, {"C4": "upper2", "E4": "upper2", "C3": "lower", "D4": "upper"})
+        rests = [s.position for s in symbols if s.rhythm.startswith("rest")]
+        self.assertEqual(rests, ["upper", "lower2"])
+
+    def test_round_trip_of_two_voices_on_one_staff(self) -> None:
+        """tokens -> MusicXML -> tokens keeps the two upper voices apart.
+
+        Which one ends up as `upper` and which as `upper2` may swap: the generator
+        numbers the MusicXML voices by rhythmic layer (rebalance_measure_voices),
+        while we take the first visible voice of a staff as the main voice.
+        """
+        self.maxDiff = None
+        # Same input as test_music_xml_generator.test_two_voices_on_the_same_staff
+        original = """clef_G2 _ _ _ _ upper&clef_F4 _ _ _ _ lower
+keySignature_0 . . . . .
+timeSignature/4 . . . . .
+note_2 G4 _ _ _ upper&note_4 E4 _ _ _ upper2&note_1 C3 _ _ _ lower
+note_4 D4 _ _ _ upper2
+barline . . . . ."""
+        xml = generate_xml(XmlGeneratorArguments(), [read_token_lines(original.splitlines())], "")
+        tokens = music_xml_string_to_tokens(ET.tostring(xml, encoding="unicode"))
+        flat_list = [x for xxs in tokens for xs in xxs for x in xs]
+        positions = {s.pitch: s.position for s in flat_list if s.rhythm.startswith("note")}
+        self.assertEqual(positions["C3"], "lower")
+        self.assertEqual(positions["E4"], positions["D4"])
+        self.assertEqual({positions["G4"], positions["E4"]}, {"upper", "upper2"})
 
     def _norm_expected(self, expected: str) -> str:
         norm = expected.replace("\n", "")

--- a/training/omr_datasets/convert_lieder.py
+++ b/training/omr_datasets/convert_lieder.py
@@ -19,7 +19,7 @@ from PIL import Image
 from homr.circle_of_fifths import strip_naturals
 from homr.download_utils import download_file, unzip_file
 from homr.simple_logging import eprint
-from homr.transformer.vocabulary import EncodedSymbol, empty
+from homr.transformer.vocabulary import EncodedSymbol, empty, is_lower_position
 from training.omr_datasets.musescore_svg import (
     SvgMusicFile,
     SvgStaff,
@@ -373,7 +373,7 @@ class MeasureCutter:
         self.time = EncodedSymbol("timeSignature/4")
 
     def _position_to_staff_no(self, symbol: EncodedSymbol) -> int:
-        if symbol.position == "lower":
+        if is_lower_position(symbol.position):
             return 1
         return 0
 

--- a/training/omr_datasets/humdrum_kern_parser.py
+++ b/training/omr_datasets/humdrum_kern_parser.py
@@ -159,7 +159,7 @@ def _convert_into_staffs(lines: list[str]) -> tuple[list[list[EncodedSymbolWithP
         # empty
         if not line.strip():
             for staff in staffs:
-                staff.feed("")
+                staff.feed([""])
             continue
 
         # comment
@@ -217,8 +217,8 @@ def _convert_into_staffs(lines: list[str]) -> tuple[list[list[EncodedSymbolWithP
         grouped: dict[HumdrumKernConverter, list[str]] = {}
         for staff, tok in zip(spine_to_staff, tokens, strict=True):
             grouped.setdefault(staff, []).append(tok)
-        for staff, items in grouped.items():
-            staff.feed(" ".join(items))
+        for staff, voices in grouped.items():
+            staff.feed(voices)
 
     return [staff.state.result for staff in staffs], warnings
 
@@ -418,8 +418,10 @@ class HumdrumKernConverter:
         }
         return [EncodedSymbol(s) for s in mapping[symbol]]
 
-    def feed(self, line: str) -> None:
+    def feed(self, voices: list[str]) -> None:
+        """Process one kern line of this staff, with one entry in voices per voice."""
         s = self.state
+        line = " ".join(voices)
         s.advance_line_no(line)
         if line.startswith("="):
             s.add_barline(self.parse_barline(line))
@@ -435,17 +437,23 @@ class HumdrumKernConverter:
         else:
             if line.strip():  # blank lines are formatting, not data
                 s.data_seen = True
-            chord_dur = "4"
-            first = True
-            for token in line.split():
-                if token == nonote:
-                    continue
-                if first:
-                    extracted = self._extract_dur(token)
-                    if extracted:
-                        chord_dur = extracted
-                    first = False
-                s.add_note(self.parse_note_or_rest(token, s.position.value, chord_dur))
+            for i, voice in enumerate(voices):
+                # We accept at most 2 voices per staff.
+                # Everything beyond 2nd is folded into 2nd.
+                position = s.position.value
+                if i >= 1:
+                    position = s.position.value + "2"
+                chord_dur = "4"
+                first = True
+                for token in voice.split():
+                    if token == nonote:
+                        continue
+                    if first:
+                        extracted = self._extract_dur(token)
+                        if extracted:
+                            chord_dur = extracted
+                        first = False
+                    s.add_note(self.parse_note_or_rest(token, position, chord_dur))
 
 
 if __name__ == "__main__":

--- a/training/omr_datasets/humdrum_kern_parser.py
+++ b/training/omr_datasets/humdrum_kern_parser.py
@@ -1,6 +1,5 @@
-import copy
 import re
-from typing import NamedTuple
+from enum import Enum
 
 from homr.circle_of_fifths import strip_naturals
 from homr.transformer.vocabulary import EncodedSymbol, empty, nonote
@@ -11,167 +10,217 @@ from training.omr_datasets.staff_merging import (
 from training.transformer.training_vocabulary import VocabularyStats, check_token_lines
 
 
-class _SignatureState(NamedTuple):
-    """The clef/key/time signature in force at the end of a staff's kern document.
+class StaffPosition(Enum):
+    UPPER = "upper"
+    LOWER = "lower"
 
-    Carried across concatenated multi-document kern (one document per system) so a
-    system's opening clef/key/time is only emitted as a token when it actually differs
-    from what was already in force - not just because the document restarts.
-    """
 
-    clef: EncodedSymbol
-    key: EncodedSymbol
-    time: EncodedSymbol
+# How much a barline token says about the line it describes, see _merge_barlines.
+_BARLINE_RANK = {
+    "barline": 0,
+    "doublebarline": 1,
+    "bolddoublebarline": 2,
+    "repeatStart": 3,
+    "repeatEnd": 3,
+    "repeatEndStart": 4,
+}
+
+
+def _merge_barlines(kept: EncodedSymbol, dropped: EncodedSymbol) -> EncodedSymbol:
+    """Combine two barlines which the image draws as a single one."""
+    if {kept.rhythm, dropped.rhythm} == {"repeatEnd", "repeatStart"}:
+        return EncodedSymbol("repeatEndStart")
+    if _BARLINE_RANK.get(dropped.rhythm, -1) > _BARLINE_RANK[kept.rhythm]:
+        return dropped
+    return kept
+
+
+class _StaffState:
+    def __init__(self, position: StaffPosition) -> None:
+        clef_name = "clef_G2" if position is StaffPosition.UPPER else "clef_F4"
+        self.clef = EncodedSymbolWithPos(
+            -10, EncodedSymbol(clef_name, empty, empty, empty, empty, position.value)
+        )
+        self.key = EncodedSymbolWithPos(-9, EncodedSymbol("keySignature_0"))
+        self.time = EncodedSymbolWithPos(-8, EncodedSymbol("timeSignature/4"))
+        self.explicit_clef_seen = False
+
+        self.position = position
+        self.result: list[EncodedSymbolWithPos] = []
+        self.opening_added = False
+        self.data_seen = False
+        self.line_no = 0
+        self.in_control_group = True
+
+    def advance_line_no(self, line: str) -> None:
+        # Control chars seem to have no specific order and must be treated
+        # as if we would be on the same line.
+        control_line = line.startswith("*")
+        if control_line and self.in_control_group:
+            return
+        self.line_no += 1
+        self.in_control_group = control_line
+
+    def add_barline(self, symbols: list[EncodedSymbol]) -> None:
+        """Add a barline, or merge it into the one before if the image draws them as one.
+
+        Kern can write two barlines without anything in between, a repeat end followed
+        by a repeat start for example, or the barline a staff system ends with followed
+        by the same barline again at the start of the next system. A data line of rests
+        or even placeholders (see nonote) means the staff has moved on and whatever
+        barline comes next is a line of its own.
+        """
+        if not self.data_seen:
+            if symbols and self.result and self.result[-1].rhythm in _BARLINE_RANK:
+                self.result[-1] = EncodedSymbolWithPos(
+                    self.result[-1].position, _merge_barlines(self.result[-1].symbol, symbols[0])
+                )
+            return
+        if symbols:
+            self.data_seen = False
+        self.result.extend(EncodedSymbolWithPos(self.line_no, sym) for sym in symbols)
+
+    def set_key(self, new_key: EncodedSymbol) -> None:
+        if self.opening_added and new_key != self.key.symbol:
+            self.result.append(EncodedSymbolWithPos(self.line_no, new_key))
+        self.key = EncodedSymbolWithPos(-9, new_key)
+
+    def set_time(self, new_time: EncodedSymbol) -> None:
+        if self.opening_added and new_time != self.time.symbol:
+            self.result.append(EncodedSymbolWithPos(self.line_no, new_time))
+        self.time = EncodedSymbolWithPos(-8, new_time)
+
+    def set_clef(self, new_clef: EncodedSymbol) -> None:
+        if self.opening_added and (not self.explicit_clef_seen or new_clef != self.clef.symbol):
+            self.result.append(EncodedSymbolWithPos(self.line_no, new_clef))
+        self.explicit_clef_seen = True
+        self.clef = EncodedSymbolWithPos(-10, new_clef)
+
+    def add_note(self, symbol: EncodedSymbol) -> None:
+        if not self.opening_added:
+            self.result.extend([self.clef, self.key, self.time])
+            self.opening_added = True
+        self.result.append(EncodedSymbolWithPos(self.line_no, symbol))
 
 
 def convert_kern_to_tokens(lines: list[str]) -> list[EncodedSymbol]:
-    staffs = _merge_multiple_voices_on_the_same_staff(lines)
-    merged = merge_upper_and_lower_staff(
-        [
-            _convert_single_staff(staff_no, staff)[0]
-            for staff_no, staff in enumerate(reversed(staffs))
-        ]
-    )
-    merged = _remove_redundant_key_changes(merged)
-    merged = _fix_final_repeat_start(merged)
-    merged = strip_naturals(merged)
-    return merged
+    staffs, warnings = _convert_into_staffs(lines)
+    if warnings:
+        raise ValueError(" ".join(warnings))
+    if len(staffs) != 2:
+        raise ValueError("Skip scores with only 1 staff")
+    staffs = list(reversed(staffs))  # reverse to get treble first
+    return _post_process(merge_upper_and_lower_staff(staffs))
 
 
 def convert_kern_to_parts(lines: list[str]) -> list[list[EncodedSymbol]]:
-    """Return one token list per spine group for part-by-part NED comparison.
-
-    Two-spine grand-staff scores are reversed so treble comes first, matching
-    how _split_grand_staff orders MusicXML parts (staff 1 = treble first).
-    All other spine counts preserve the original spine order, which music21
-    also preserves in its XML output.
-
-    Handles concatenated multi-document kern (multiple **kern...*- sections, as
-    produced by datasets that store one kern document per staff system) by parsing
-    each document separately and extending the corresponding parts. The clef/key/time
-    signature in force is carried from one document to the next, so a system's opening
-    declarations only become tokens when they are an actual change - not just because
-    every system re-prints them (see _SignatureState).
-    """
-    docs = _split_kern_documents(lines)
-    if len(docs) == 1:
-        parts, _carry = _parse_kern_document(docs[0])
-        return parts
-
-    carry: list[_SignatureState] | None = None
-    doc_parts_list: list[list[list[EncodedSymbol]]] = []
-    for doc in docs:
-        parts, carry = _parse_kern_document(doc, carry)
-        doc_parts_list.append(parts)
-
-    n_parts = max(len(p) for p in doc_parts_list)
-    merged: list[list[EncodedSymbol]] = [[] for _ in range(n_parts)]
-    for doc_parts in doc_parts_list:
-        for i, part in enumerate(doc_parts):
-            merged[i].extend(part)
-    return merged
+    staffs, _ = _convert_into_staffs(lines)
+    # NED ignores Position, so no need to reverse the staffs
+    return [_post_process(merge_upper_and_lower_staff([staff])) for staff in staffs]
 
 
-def _split_kern_documents(lines: list[str]) -> list[list[str]]:
-    """Split a (possibly concatenated) kern text into individual documents."""
-    docs: list[list[str]] = []
-    current: list[str] = []
+def _post_process(symbols: list[EncodedSymbol]) -> list[EncodedSymbol]:
+    symbols = _remove_redundant_key_changes(symbols)
+    symbols = _fix_final_repeat_start(symbols)
+    return strip_naturals(symbols)
+
+
+def _convert_into_staffs(lines: list[str]) -> tuple[list[list[EncodedSymbolWithPos]], list[str]]:
+    def _is_exordium(tokens: list[str]) -> bool:
+        return all(tok.startswith("**") for tok in tokens)
+
+    # Count staffs in a first pass before actual parsing. Staff count is the number of
+    # spines, but a later document may open extra spines, so take the minimum.
+    num_of_staffs = 999
     for line in lines:
-        current.append(line)
-        stripped = line.strip()
-        if stripped and all(tok.strip() == "*-" for tok in stripped.split("\t")):
-            docs.append(current)
-            current = []
-    if current:
-        docs.append(current)
-    return docs or [lines]
+        tokens = line.rstrip("\n").split("\t")
+        if _is_exordium(tokens):
+            num_of_staffs = min(num_of_staffs, len(tokens))
+    assert num_of_staffs != 999, "No exordium found"  # noqa: S101
 
-
-def _parse_kern_document(
-    lines: list[str], carry: list[_SignatureState] | None = None
-) -> tuple[list[list[EncodedSymbol]], list[_SignatureState]]:
-    staffs = _merge_multiple_voices_on_the_same_staff(lines)
-    ordered = list(reversed(staffs)) if len(staffs) == 2 else staffs
-    result = []
-    new_carry: list[_SignatureState] = []
-    for staff_no, staff in enumerate(ordered):
-        initial = carry[staff_no] if carry is not None and staff_no < len(carry) else None
-        single, final_state = _convert_single_staff(staff_no, staff, initial)
-        part = merge_upper_and_lower_staff([single])
-        part = _remove_redundant_key_changes(part)
-        part = _fix_final_repeat_start(part)
-        part = strip_naturals(part)
-        result.append(part)
-        new_carry.append(final_state)
-    return result, new_carry
-
-
-def _merge_multiple_voices_on_the_same_staff(
-    lines: list[str],
-) -> list[list[str]]:
-    """
-    Merges voices into staffs.
-
-    Humdrum kern uses special symbols: *^ and *v to split and merge voices
-    """
-    staff_lines: list[list[str]] = []
-    spine_to_staff: list[int] = []
+    # Typically we expect num_of_staffs == 2, which the training dataset
+    # `grandstaff`` mostly follows.
+    # Kern lists the bass staff first and the treble staff second, so the code here should work.
+    #
+    # However, in the validation dataset `smb`, kern scores concatenate several documents,
+    # so num_of_staffs != 2. Then we cannot tell the StaffPosition and assign one arbitrarily.
+    # NED ignores Position, so the assignment does not affect NED correctness.
+    staffs = [
+        HumdrumKernConverter(StaffPosition.LOWER if i == 0 else StaffPosition.UPPER)
+        for i in range(num_of_staffs)
+    ]
+    # Indexed by spine, several spines can point to the same staff (see Split)
+    spine_to_staff: list[HumdrumKernConverter] = []
+    warnings: list[str] = []
 
     for raw_line in lines:
         line = raw_line.rstrip("\n")
+
+        # empty
         if not line.strip():
-            for staff in staff_lines:
-                staff.append("")
+            for staff in staffs:
+                staff.feed("")
             continue
 
+        # comment
+        if line.startswith("!"):
+            continue
+
+        # real processing
         tokens = line.split("\t")
+        num_of_spine = len(tokens)
 
-        # Initialize spines
-        if all(tok.startswith("**") for tok in tokens):
-            spine_to_staff = list(range(len(tokens)))
-            staff_lines = [[] for _ in range(max(spine_to_staff) + 1)]
-            for i in range(len(staff_lines)):
-                staff_lines[i].append("**kern")
+        # Exordium. Spines beyond the staff count belong to a staff which carries two
+        # voices without being split with "*^" (see _count_staffs). We assume they are the
+        # bass staff, which is where they usually are.
+        if _is_exordium(tokens):
+            if num_of_spine == num_of_staffs:
+                spine_to_staff = staffs
+            else:
+                # special case for validation dataset `smb`:
+                # one staff carries two voices without being split with "*^",
+                # so num_of_spine != num_of_staffs. Here we assume the extra spines
+                # belong to the bass staff, which is where they usually are.
+                spine_to_staff = [staffs[0]] * (num_of_spine - num_of_staffs + 1) + staffs[1:]
             continue
 
-        # Split
-        if "*^" in tokens:
-            new_map = []
-            for i, tok in enumerate(tokens):
-                if tok == "*^":
-                    new_map.extend([spine_to_staff[i], spine_to_staff[i]])
-                else:
-                    new_map.append(spine_to_staff[i])
-            spine_to_staff = new_map
-            continue
+        assert num_of_spine == len(spine_to_staff), "Number of spines does not match"  # noqa: S101
 
-        # Join
-        elif "*v" in tokens:
+        # Spine operations: "*^" splits a spine into two voices, "*v" joins them
+        # back into one. Both can appear on the same line.
+        if "*^" in tokens or "*v" in tokens:
             new_map = []
             i = 0
-            while i < len(tokens):
-                if i + 1 < len(tokens) and tokens[i] == "*v" and tokens[i + 1] == "*v":
-                    new_map.append(spine_to_staff[i])
-                    i += 2
-                else:
-                    new_map.append(spine_to_staff[i])
+            while i < num_of_spine:
+                staff = spine_to_staff[i]
+                if tokens[i] == "*^":
+                    new_map.extend([staff, staff])
                     i += 1
+                    continue
+                new_map.append(staff)
+                if tokens[i] != "*v":
+                    i += 1
+                    continue
+                end = i + 1
+                # count how many *v there are.
+                while end < num_of_spine and tokens[end] == "*v":
+                    end += 1
+                for _staff in spine_to_staff[i + 1 : end]:
+                    if _staff is not staff:
+                        warnings.append("voices to join should point to the same staff")
+                        break
+                i = end
             spine_to_staff = new_map
             continue
 
         # Data line
-        grouped: dict[int, list[str]] = {}
-        for i, tok in enumerate(tokens):
-            if i >= len(spine_to_staff):
-                continue  # skip extra unexpected tokens
-            s = spine_to_staff[i]
-            grouped.setdefault(s, []).append(tok)
-        for s, items in grouped.items():
-            while len(staff_lines) <= s:
-                staff_lines.append([])
-            staff_lines[s].append(" ".join(items))
+        grouped: dict[HumdrumKernConverter, list[str]] = {}
+        for staff, tok in zip(spine_to_staff, tokens, strict=True):
+            grouped.setdefault(staff, []).append(tok)
+        for staff, items in grouped.items():
+            staff.feed(" ".join(items))
 
-    return staff_lines
+    return [staff.state.result for staff in staffs], warnings
 
 
 def _remove_redundant_key_changes(symbols: list[EncodedSymbol]) -> list[EncodedSymbol]:
@@ -203,15 +252,8 @@ def _fix_final_repeat_start(symbols: list[EncodedSymbol]) -> list[EncodedSymbol]
     return symbols
 
 
-def _convert_single_staff(
-    staff_no: int, lines: list[str], initial: _SignatureState | None = None
-) -> tuple[list[EncodedSymbolWithPos], _SignatureState]:
-    converter = HumdrumKernConverter()
-    return converter.convert_humdrum_kern(staff_no, lines, initial)
-
-
 class HumdrumKernConverter:
-    def __init__(self) -> None:
+    def __init__(self, position: StaffPosition) -> None:
         # Grandstaff definitions: https://link.springer.com/article/10.1007/s10032-023-00432-z#Tab1
         self.ignore_beams = ("L", "J", "K", "k")
         self.ignore_alteration_displays = ("x", "X", "i", "I", "j", "Z", "y", "Y")
@@ -219,6 +261,8 @@ class HumdrumKernConverter:
         # According to the grandstaff paper angleBracketOpen & Close stands for tieStart and tieEnd
         # but there is no tie visible
         self.angled_brackets = ("<", ">")
+
+        self.state = _StaffState(position)
 
     def _accidental_to_lift(self, accidental: str) -> str:
         return {"-": "b", "--": "bb", "#": "#", "##": "##", "n": "N"}.get(accidental, empty)
@@ -273,11 +317,11 @@ class HumdrumKernConverter:
             # return empty, empty in line 148
             return empty, empty
 
-    def parse_clef(self, clef: str) -> EncodedSymbol:
+    def parse_clef(self, clef: str, position: str) -> EncodedSymbol:
         clef_name = clef.split(maxsplit=1)[0].replace("*clef", "clef_")
         defaults = {"clef_F": "clef_F4", "clef_G": "clef_G2", "clef_C": "clef_C3"}
         clef_name = defaults.get(clef_name, clef_name)
-        return EncodedSymbol(clef_name, empty, empty, empty, empty)
+        return EncodedSymbol(clef_name, empty, empty, empty, empty, position)
 
     def parse_key_signature(self, key_signature: str) -> EncodedSymbol:
         mapping = {
@@ -297,6 +341,7 @@ class HumdrumKernConverter:
             "*k[f#c#g#d#a#e#]": 6,
             "*k[f#c#g#d#a#e#b#]": 7,
             "*kcancel": 0,
+            "*kcancek": 0,  # typo for *kcancel in smb sample 267
         }
         circle = mapping[key_signature.split(maxsplit=1)[0]]
         return EncodedSymbol(f"keySignature_{circle}")
@@ -327,7 +372,9 @@ class HumdrumKernConverter:
         m = self._DUR_RE.match(token)
         return m.group(1) if m else None
 
-    def parse_note_or_rest(self, token: str, default_dur: str = "4") -> EncodedSymbol:
+    def parse_note_or_rest(
+        self, token: str, position: str, default_dur: str = "4"
+    ) -> EncodedSymbol:
         # Prefix: slur/tie/accent/stem/roll/alteration markers before the duration.
         # Between duration and pitch: grace note q, sforzando ^^, tuplet % ratios, etc.
         # Non-capturing group for "between" keeps group indices identical to before.
@@ -345,125 +392,60 @@ class HumdrumKernConverter:
 
         rhythm_key = self.parse_duration(dur or default_dur, is_rest=is_rest, is_grace=is_grace)
         if is_rest:
-            return EncodedSymbol(rhythm_key, empty, empty, empty, empty)
+            return EncodedSymbol(rhythm_key, empty, empty, empty, empty, position)
 
         lift_val = self._accidental_to_lift(accidental)
         pitch_val = self.kern_note_to_pitch(pitch)
         articulation_val, slur_val = self._articulation_from_suffix(suffix)
-        return EncodedSymbol(rhythm_key, pitch_val, lift_val, articulation_val, slur_val)
+        return EncodedSymbol(rhythm_key, pitch_val, lift_val, articulation_val, slur_val, position)
 
     def parse_barline(self, line: str) -> list[EncodedSymbol]:
         symbol = line.split(" ", maxsplit=1)[0]
+        # A fermata over the barline is not a barline shape of its own.
+        symbol = symbol.rstrip(";")
         mapping = {
             "=:|!|:": ["repeatEndStart"],
             "=": ["barline"],
             "=-": [],  # barline after clef, key and time sig
             "==:|!": ["repeatEnd"],
             "==": ["bolddoublebarline"],
+            "==!!": ["bolddoublebarline"],
             "=:|!": ["repeatEnd"],
             "=!|:": ["repeatStart"],
+            "=:!!:": ["repeatEndStart"],
             "=||": ["doublebarline"],
             "=|!": ["barline"],
         }
         return [EncodedSymbol(s) for s in mapping[symbol]]
 
-    def _get_default_clef(self, staff_no: int) -> EncodedSymbol:
-        if staff_no == 0:
-            return EncodedSymbol("clef_G2", empty, empty, empty, empty, "upper")
-        return EncodedSymbol("clef_F4", empty, empty, empty, empty, "lower")
-
-    def _add_line_numbers(self, lines: list[str]) -> list[tuple[int, str]]:
-        """
-        Control chars seem to have no specific order and must be treated
-        as if we would be on the same line.
-        """
-        line_no = 0
-        result: list[tuple[int, str]] = []
-        in_control_group = True
-        for line in lines:
-            control_line = line.startswith("*")
-            if control_line and in_control_group:
-                result.append((line_no, line))
-            else:
-                line_no += 1
-                result.append((line_no, line))
-                in_control_group = control_line
-        return result
-
-    def convert_humdrum_kern(
-        self, staff_no: int, lines: list[str], initial: _SignatureState | None = None
-    ) -> tuple[list[EncodedSymbolWithPos], _SignatureState]:  # noqa: C901
-        result: list[EncodedSymbolWithPos] = []
-
-        prev_clef = initial.clef if initial is not None else self._get_default_clef(staff_no)
-        prev_key = initial.key if initial is not None else EncodedSymbol("keySignature_0")
-        prev_time = initial.time if initial is not None else EncodedSymbol("timeSignature/4")
-
-        clef = EncodedSymbolWithPos(-10, prev_clef)
-        keySignature = EncodedSymbolWithPos(-9, prev_key)
-        timeSignature = EncodedSymbolWithPos(-8, prev_time)
-        initial_signature_was_added = False
-        for line_no, line in self._add_line_numbers(lines):
-            if line.startswith("="):
-                if initial_signature_was_added:
-                    parsed = self.parse_barline(line)
-                    result.extend([EncodedSymbolWithPos(line_no, p) for p in parsed])
-            elif line.startswith("*k"):
-                new_key = self.parse_key_signature(line)
-                if initial_signature_was_added and new_key != keySignature.symbol:
-                    result.append(EncodedSymbolWithPos(line_no, new_key))
-                keySignature = EncodedSymbolWithPos(-9, new_key)
-            elif line.startswith("*M"):
-                new_time = self.parse_time_signature(line)
-                if initial_signature_was_added and new_time != timeSignature.symbol:
-                    result.append(EncodedSymbolWithPos(line_no, new_time))
-                timeSignature = EncodedSymbolWithPos(-8, new_time)
-            elif line.startswith("*clef"):
-                new_clef = self.parse_clef(line)
-                if initial_signature_was_added and new_clef != clef.symbol:
-                    result.append(EncodedSymbolWithPos(line_no, new_clef))
-                clef = EncodedSymbolWithPos(-10, new_clef)
-            elif line.startswith("*"):
-                # All other control instructions can be ignored
-                pass
-            else:
-                if not initial_signature_was_added:
-                    # Symbols can be appear in various order
-                    # and duplicated (in which the latest wins). With no carried-over
-                    # state (the very first document of a piece), always emit - that is
-                    # the real start of the piece, regardless of whether it happens to
-                    # match our internal defaults. With carried-over state (a later
-                    # system in a multi-document kern file, see _SignatureState), only
-                    # emit if it actually changed - a system restart re-declaring the
-                    # same clef/key/time is not a real change.
-                    if initial is None or clef.symbol != prev_clef:
-                        result.append(clef)
-                    if initial is None or keySignature.symbol != prev_key:
-                        result.append(keySignature)
-                    if initial is None or timeSignature.symbol != prev_time:
-                        result.append(timeSignature)
-                    initial_signature_was_added = True
-                symbols = line.split()
-                chord_dur = "4"
-                first = True
-                for token in symbols:
-                    if token == nonote:
-                        continue
-                    if first:
-                        extracted = self._extract_dur(token)
-                        if extracted:
-                            chord_dur = extracted
-                        first = False
-                    result.append(
-                        EncodedSymbolWithPos(line_no, self.parse_note_or_rest(token, chord_dur))
-                    )
-
-        # Snapshot independent copies: the symbols above are later mutated in place
-        # (e.g. merge_upper_and_lower_staff fills in symbol.position), so returning the
-        # same objects would let that later mutation leak back into the carried state.
-        return result, _SignatureState(
-            copy.copy(clef.symbol), copy.copy(keySignature.symbol), copy.copy(timeSignature.symbol)
-        )
+    def feed(self, line: str) -> None:
+        s = self.state
+        s.advance_line_no(line)
+        if line.startswith("="):
+            s.add_barline(self.parse_barline(line))
+        elif line.startswith("*k"):
+            s.set_key(self.parse_key_signature(line))
+        elif line.startswith("*M"):
+            s.set_time(self.parse_time_signature(line))
+        elif line.startswith("*clef"):
+            s.set_clef(self.parse_clef(line, s.position.value))
+        elif line.startswith("*"):
+            # All other control instructions can be ignored
+            pass
+        else:
+            if line.strip():  # blank lines are formatting, not data
+                s.data_seen = True
+            chord_dur = "4"
+            first = True
+            for token in line.split():
+                if token == nonote:
+                    continue
+                if first:
+                    extracted = self._extract_dur(token)
+                    if extracted:
+                        chord_dur = extracted
+                    first = False
+                s.add_note(self.parse_note_or_rest(token, s.position.value, chord_dur))
 
 
 if __name__ == "__main__":

--- a/training/omr_datasets/music_xml_parser.py
+++ b/training/omr_datasets/music_xml_parser.py
@@ -8,6 +8,7 @@ from homr.transformer.vocabulary import (
     EncodedSymbol,
     empty,
     has_rhythm_symbol_a_position,
+    is_lower_position,
 )
 from training.omr_datasets.staff_merging import (
     EncodedSymbolWithPos,
@@ -133,6 +134,7 @@ class TokensMeasure:
 
     def __init__(self) -> None:
         self.symbols: list[EncodedSymbolWithPos] = []
+        self.main_voice: dict[int, int] = {}  # map staff id to its main voice id
         self.current_position = 0
         self.new_page = False
 
@@ -164,15 +166,31 @@ class TokensMeasure:
         self.current_position = new_position
 
     def append_rest(
-        self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
+        self,
+        staff: int,
+        voice: int,
+        is_chord: bool,
+        duration: int,
+        invisible: bool,
+        symbol: EncodedSymbol,
     ) -> None:
-        self.append_note(staff, is_chord, duration, invisible, symbol)
+        self.append_note(staff, voice, is_chord, duration, invisible, symbol)
 
     def append_note(
-        self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
+        self,
+        staff: int,
+        voice: int,
+        is_chord: bool,
+        duration: int,
+        invisible: bool,
+        symbol: EncodedSymbol,
     ) -> None:
         is_grace = "G" in symbol.rhythm
         symbol.position = self._get_staff_position(staff)
+        if not invisible:
+            # The first visible voice of each staff is the main voice in this measure.
+            if voice != self.main_voice.setdefault(staff, voice):
+                symbol.position += "2"
         if is_chord:
             previous_symbol = self.symbols[-1]
             if not invisible:
@@ -188,7 +206,7 @@ class TokensMeasure:
             self.current_position += duration
 
     def _get_staff_no(self, symbol: EncodedSymbolWithPos) -> int:
-        if symbol.symbol.position == "lower":
+        if is_lower_position(symbol.symbol.position):
             return 1
         return 0
 
@@ -377,16 +395,32 @@ class TokensPart:
         self._ensure_current_measure().mark_new_page()
 
     def append_rest(
-        self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
+        self,
+        staff: int,
+        voice: int,
+        is_chord: bool,
+        duration: int,
+        invisible: bool,
+        symbol: EncodedSymbol,
     ) -> None:
         self._flush_pending_clefs()
-        self._ensure_current_measure().append_rest(staff, is_chord, duration, invisible, symbol)
+        self._ensure_current_measure().append_rest(
+            staff, voice, is_chord, duration, invisible, symbol
+        )
 
     def append_note(
-        self, staff: int, is_chord: bool, duration: int, invisible: bool, symbol: EncodedSymbol
+        self,
+        staff: int,
+        voice: int,
+        is_chord: bool,
+        duration: int,
+        invisible: bool,
+        symbol: EncodedSymbol,
     ) -> None:
         self._flush_pending_clefs()
-        self._ensure_current_measure().append_note(staff, is_chord, duration, invisible, symbol)
+        self._ensure_current_measure().append_note(
+            staff, voice, is_chord, duration, invisible, symbol
+        )
 
     def append_position_change(self, duration: int) -> None:
         self._flush_pending_clefs()
@@ -573,6 +607,8 @@ def _process_note(part: TokensPart, note: ET.Element) -> None:
     invisible = print_object == "no"
     if len(staff_nodes) > 0:
         staff = _int_text(staff_nodes[0], 1) - 1
+    voice_nodes = _children(note, "voice")
+    voice = _int_text(voice_nodes[0], 0) if voice_nodes else 0
     is_grace = _child(note, "grace") is not None
     is_chord = _child(note, "chord") is not None
     duration_node = _child(note, "duration")
@@ -597,6 +633,7 @@ def _process_note(part: TokensPart, note: ET.Element) -> None:
             rhythm = _measure_rest_rhythm(duration, part.divisions)
             part.append_rest(
                 staff,
+                voice,
                 is_chord,
                 duration,
                 invisible,
@@ -605,7 +642,7 @@ def _process_note(part: TokensPart, note: ET.Element) -> None:
         else:
             rhythm = _rhythm_token("rest", base_duration, dots, is_grace)
             sym = EncodedSymbol(rhythm, empty, empty, art, slur)
-            part.append_rest(staff, is_chord, duration, invisible, sym)
+            part.append_rest(staff, voice, is_chord, duration, invisible, sym)
     pitch = _children(note, "pitch")
     if len(pitch) > 0:
         pitch_name = _pitch_name(pitch[0])
@@ -613,7 +650,7 @@ def _process_note(part: TokensPart, note: ET.Element) -> None:
         rhythm = _rhythm_token("note", base_duration, dots, is_grace)
         sym = EncodedSymbol(rhythm, pitch_name, lift, art, slur)
 
-        part.append_note(staff, is_chord, max(duration, 1), invisible, sym)
+        part.append_note(staff, voice, is_chord, max(duration, 1), invisible, sym)
 
 
 def _process_backup(part: TokensPart, backup: ET.Element) -> None:

--- a/training/omr_datasets/staff_merging.py
+++ b/training/omr_datasets/staff_merging.py
@@ -1,10 +1,6 @@
 from collections import defaultdict
 
-from homr.transformer.vocabulary import (
-    EncodedSymbol,
-    has_rhythm_symbol_a_position,
-    nonote,
-)
+from homr.transformer.vocabulary import EncodedSymbol
 
 
 class EncodedSymbolWithPos:
@@ -27,14 +23,8 @@ class EncodedSymbolWithPos:
 def merge_upper_and_lower_staff(voices: list[list[EncodedSymbolWithPos]]) -> list[EncodedSymbol]:
     voices = [voice for voice in voices if len(voice) > 0]
     positions: defaultdict[int, list[EncodedSymbol]] = defaultdict(list)
-    for voice_no, voice in enumerate(voices):
-        position = "upper" if voice_no == 0 else "lower"
+    for voice in voices:
         for symbol in voice:
-            if (
-                has_rhythm_symbol_a_position(symbol.symbol.rhythm)
-                and symbol.symbol.position == nonote
-            ):
-                symbol.symbol.position = position
             positions[symbol.sort_order()].append(symbol.symbol)
 
     result: list[EncodedSymbol] = []

--- a/training/transformer/training_vocabulary.py
+++ b/training/transformer/training_vocabulary.py
@@ -10,6 +10,7 @@ from homr.transformer.vocabulary import (
     Vocabulary,
     empty,
     has_rhythm_symbol_a_position,
+    is_lower_position,
     nonote,
     sort_token_chords,
 )
@@ -61,7 +62,7 @@ def check_token_lines(lines: list[EncodedSymbol]) -> None:
 
 
 def _symbol_to_sortable(symbol: EncodedSymbol) -> int:
-    position = 10000000 if symbol.position == "lower" else 0
+    position = 10000000 if is_lower_position(symbol.position) else 0
     if "note" in symbol.rhythm:
         return (
             vocab.pitch[symbol.pitch] * len(vocab.rhythm) + vocab.rhythm[symbol.rhythm] + position
@@ -83,12 +84,12 @@ def _chord_to_str(chord: list[EncodedSymbol]) -> str:
         artic_stripped, symbol_stripped = symbol.strip_articulations([], remove_all=True)
         slur_stripped, symbol_stripped = symbol_stripped.strip_slurs([], remove_all=True)
         for articulation in artic_stripped:
-            if symbol.position == "lower":
+            if is_lower_position(symbol.position):
                 lower_artics.add(articulation)
             else:
                 upper_artics.add(articulation)
         for slur in slur_stripped:
-            if symbol.position == "lower":
+            if is_lower_position(symbol.position):
                 lower_slurs.add(slur)
             else:
                 upper_slurs.add(slur)
@@ -107,7 +108,8 @@ def _chord_to_str(chord: list[EncodedSymbol]) -> str:
 
     if len(upper_slurs) > 0:
         first_upper = next(
-            (idx for idx, s in enumerate(annotation_resorted) if s.position != "lower"), None
+            (idx for idx, s in enumerate(annotation_resorted) if not is_lower_position(s.position)),
+            None,
         )
         if first_upper is not None:
             annotation_resorted[first_upper] = annotation_resorted[first_upper].add_slurs(
@@ -115,7 +117,8 @@ def _chord_to_str(chord: list[EncodedSymbol]) -> str:
             )
     if len(lower_slurs) > 0:
         first_lower = next(
-            (idx for idx, s in enumerate(annotation_resorted) if s.position == "lower"), None
+            (idx for idx, s in enumerate(annotation_resorted) if is_lower_position(s.position)),
+            None,
         )
         if first_lower is not None:
             annotation_resorted[first_lower] = annotation_resorted[first_lower].add_slurs(
@@ -124,7 +127,8 @@ def _chord_to_str(chord: list[EncodedSymbol]) -> str:
 
     if len(upper_artics) > 0:
         first_upper = next(
-            (idx for idx, s in enumerate(annotation_resorted) if s.position != "lower"), None
+            (idx for idx, s in enumerate(annotation_resorted) if not is_lower_position(s.position)),
+            None,
         )
         if first_upper is not None:
             annotation_resorted[first_upper] = annotation_resorted[first_upper].add_articulations(
@@ -132,7 +136,8 @@ def _chord_to_str(chord: list[EncodedSymbol]) -> str:
             )
     if len(lower_artics) > 0:
         first_lower = next(
-            (idx for idx, s in enumerate(annotation_resorted) if s.position == "lower"), None
+            (idx for idx, s in enumerate(annotation_resorted) if is_lower_position(s.position)),
+            None,
         )
         if first_lower is not None:
             annotation_resorted[first_lower] = annotation_resorted[first_lower].add_articulations(
@@ -173,12 +178,13 @@ def max_ledger_lines(tokens: list[EncodedSymbol]) -> int:
     }
     max_ledger_lines = 0
     for symbol in tokens:
+        family = symbol.position.removesuffix("2")
         if symbol.rhythm.startswith("clef"):
             anchor = _clef_anchor(symbol.rhythm)
             if anchor is None:
                 continue
-            if symbol.position in anchors:
-                anchors[symbol.position] = anchor
+            if family in anchors:
+                anchors[family] = anchor
             else:
                 anchors["upper"] = anchor
                 anchors["lower"] = anchor
@@ -194,7 +200,7 @@ def max_ledger_lines(tokens: list[EncodedSymbol]) -> int:
         if absolute_val is None:
             continue
 
-        anchor = anchors.get(symbol.position, anchors["upper"])
+        anchor = anchors.get(family, anchors["upper"])
         if anchor is None:
             raise ValueError("Failed to get anchor")
         offset = absolute_val - anchor


### PR DESCRIPTION
## Brief introduction

As noted in #126, it's hard for homr to recognize multiple voices on a single staff, for example:

<img width="500" height="250" alt="image" src="https://github.com/user-attachments/assets/6b0bc0d1-f13a-4c63-800f-a95d78fbcbfb" />

That is because the current vocabulary only distinguishes `upper` and `lower`. This PR further distinguishes `upper`/`upper2` and `lower`/`lower2`. (I used to think this would not work — for example, what do 1 and 2 actually mean? Which voice comes first?) After training, this approach looks viable. Now homr’s recognition results look like this:

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/c607b275-f199-49ad-9f89-a1f72136c071" />

## Code details

This PR has two parts.

### Kern parser refactor

The existing parser is complex and hard to follow, especially in these two places:

1. It first merges multiple voices on the same staff, then parses. That is unnecessary; we can parse and merge in a single pass. This one-pass behaviour also helps this PR.
2. In smb dataset, one kern file can contain multiple documents, so the original parser logic was not reused. A separate `_parse_kern_document` was added instead. But I found that the logic can actually be reused.

I compared dataset parsing before and after the refactor:

1. The `.tokens` produced for grandstaff dataset are unchanged, except that about 100 low-quality files are now filtered out. I am confident this refactor will not affect training.
2. The smb dataset is more complicated, with many corner cases. After the refactor, NED changes slightly. I compared the diffs with my best effort; I believe those differences come from gaps in the original parser, i.e. the refactored code is closer to ground truth.

### Kern / MusicXML parser changes

This part is more straightforward. MusicXML already has voice data; for kern, voice data can be read from parallel spines. 

I retrained the model. Benchmark results are polish 16.89% and smb 13.72%, so there appears to be no regression at least.

This PR is still fairly complex; we can take our time reviewing it. And there are quite some test code, which are AI-generated, while other code is hand written by me